### PR TITLE
Chrome doesn't understand the alternate stylesheet tag

### DIFF
--- a/views/header.erb
+++ b/views/header.erb
@@ -33,7 +33,7 @@
 
   <% css_files.each do |css_file| %>
     <% alternate = ShowOffUtils.default_style?(css_file) ? '' : 'alternate ' %>
-    <link rel="<%= alternate %>stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
+    <link rel="stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
   <% end %>
 
   <% js_files.each do |js_file| %>


### PR DESCRIPTION
This pull request simply removes the word "alternate" from the CSS link line in the resulting html. The CSS switching might still work.
