### PR TITLE
Change 'exercise' showoff tag to 'solguide'

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -257,7 +257,7 @@ class ShowOff < Sinatra::Application
 
     def update_special_content(content)
       doc = Nokogiri::HTML::DocumentFragment.parse(content)
-      %w[notes handouts exercise].each { |mark|  update_special_content_mark(doc, mark) }
+      %w[notes handouts solguide].each { |mark|  update_special_content_mark(doc, mark) }
       doc.to_html
     end
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -229,7 +229,7 @@ h3 { font-size: 2em; }
 
 pre { margin: 1em 40px; padding: .25em; }
 
-.notes, .handouts, .exercise { display: none }
+.notes, .handouts, .solguide { display: none }
 .hidden { position:absolute; top:0; left:-9999px; width:1px; height:1px; overflow:hidden; }
 .buttonNav { display: none }
 .offscreen { position:absolute; top:0; left:-9999px; overflow:hidden; }


### PR DESCRIPTION
The 'exercise' css tag is reserved for exercise slides. Instead we will
use the solguide keyword in the slides to hide solution guides.
