### PR TITLE
Merge the d & b key handling to showoff

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -235,7 +235,19 @@ pre { margin: 1em 40px; padding: .25em; }
 .offscreen { position:absolute; top:0; left:-9999px; overflow:hidden; }
 #debugInfo { margin-left: 30px; }
 #notesInfo { margin-left: 30px; display: none }
+#debugFilename {
+    position: absolute;
+    bottom: 5px;
+    right: 10px;
+    font-size: 12px;
+}
 #preshow { display: none; }
+/* define the screen blocking view */
+/* we define it as invisible because we use jQuery to animate its presentation */
+#screenblanker {
+  height: 100%;
+  display: none;
+}
 
 #help {
     background: #9f9;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -333,10 +333,26 @@ function doDebugStuff()
 {
 	if (debugMode) {
 		$('#debugInfo').show()
+        $('.slide .content').each(function(index) {
+            $(this).prepend('<div id="debugFilename">' + $(this).attr('ref') + '</div>');
+        });
 		debug('debug mode on')
 	} else {
 		$('#debugInfo').hide()
+		$('.content #debugFilename').remove()
 	}
+}
+
+function blankScreen()
+{
+    if ($('#screenblanker').length) { // if #screenblanker exists
+        $('#screenblanker').slideUp('normal', function() {
+            $('#screenblanker').remove();
+        });
+    } else {
+        $('body').prepend('<div id="screenblanker"></div>');
+        $('#screenblanker').slideDown();
+    }
 }
 
 var notesMode = false
@@ -446,7 +462,11 @@ function keyDown(event)
 	{
 		$('#help').toggle()
 	}
-	else if (key == 66 || key == 70) // f for footer (also "b" which is what kensington remote "stop" button sends
+	else if (key == 66) // b for blank, also what kensington remote "stop" button sends
+	{
+		blankScreen()
+	}
+    	else if (key == 70) // f for footer
 	{
 		toggleFooter()
 	}


### PR DESCRIPTION
Two new keys handled by our branch of showoff:
  b => blank screen
  d => show filename in debug view

Note that the default branch also used 'b' to show/hide the footer.
This changes that behaviour. Now only 'f' toggles the footer and 'b'
will blank the screen. This is also the key sent by the 'stop' button
on many remotes, so you can blank the screen from anywhere.

Also note that you must update the Fundamentals slide deck. Otherwise the keys may conflict and exhibit undesired behaviour.
