### PR TITLE
Enables progressive downloads and analytics

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -36,6 +36,8 @@ class ShowOff < Sinatra::Application
   set :page_size, "Letter"
   set :pres_template, nil
   set :showoff_config, nil
+  set :downloads, nil
+  set :counter, nil
 
   def initialize(app=nil)
     super(app)
@@ -66,7 +68,6 @@ class ShowOff < Sinatra::Application
       settings.pres_template = showoff_json["templates"] 
     end
 
-
     @logger.debug settings.pres_template
 
     @cached_image_size = {}
@@ -76,6 +77,12 @@ class ShowOff < Sinatra::Application
 
     # Default asset path
     @asset_path = "./"
+
+    # Track downloadable files
+    @@downloads = Hash.new
+
+    # Page view time accumulator
+    @@counter = Hash.new
 
     # Initialize Markdown Configuration
     #MarkdownConfig::setup(settings.pres_dir)
@@ -210,9 +217,10 @@ class ShowOff < Sinatra::Application
         else
           content += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}\">\n"
         end
+
         sl = Tilt[:markdown].new { slide.text }.render
         sl = update_p_classes(sl)
-        sl = update_special_content(sl)
+        sl = update_special_content(sl, @slide_count, name)
         sl = update_image_paths(name, sl, static, pdf)
         content += sl
         content += "</div>\n"
@@ -255,9 +263,10 @@ class ShowOff < Sinatra::Application
       markdown.gsub(/<p>\.(.*?) /, '<p class="\1">')
     end
 
-    def update_special_content(content)
+    def update_special_content(content, seq, name)
       doc = Nokogiri::HTML::DocumentFragment.parse(content)
       %w[notes handouts solguide].each { |mark|  update_special_content_mark(doc, mark) }
+      update_download_links(doc, seq, name)
       doc.to_html
     end
 
@@ -273,6 +282,20 @@ class ShowOff < Sinatra::Application
       container.inner_html = markdown
     end
     private :update_special_content_mark
+
+    def update_download_links(doc, seq, name)
+      container = doc.css("p.download").first
+      return unless container
+
+      raw      = container.text
+      fixed    = raw.gsub(/^\.download ?/, '')
+
+      # [ enabled, path, slide name ]
+      @@downloads[seq] = [ false, fixed, name ]
+
+      container.remove
+    end
+    private :update_download_links
 
     def update_image_paths(path, slide, static=false, pdf=false)
       paths = path.split('/')
@@ -485,6 +508,37 @@ class ShowOff < Sinatra::Application
       erb :onepage
     end
 
+    def download(static=false)
+      @downloads = @@downloads
+      erb :download
+    end
+
+    def counter(static=false)
+      slide = request.params['page'].to_i
+      remote = request.env['REMOTE_HOST']
+
+      logger.debug "Ping: #{remote} : #{slide}"
+
+      # check to see if we need to enable a download link
+      if remote == 'localhost'
+        if @@downloads.has_key?(slide)
+          logger.debug "Enabling file download for slide #{slide}"
+          @@downloads[slide][0] = true
+        end
+      # otherwise, this is an audience viewer, so increment the slide view time counter
+      else
+        if not @@counter.has_key?(slide)
+          @@counter[slide] = Hash.new
+        end
+
+        if @@counter[slide].has_key?(remote)
+          @@counter[slide][remote] += 1
+        else
+          @@counter[slide][remote] = 1
+        end
+      end
+    end
+
     def pdf(static=true)
       @slides = get_slides_html(static, true)
       @inline = true
@@ -598,7 +652,11 @@ class ShowOff < Sinatra::Application
   get %r{(?:image|file)/(.*)} do
     path = params[:captures].first
     full_path = File.join(settings.pres_dir, path)
-    send_file full_path
+    if File.exist?(full_path)
+        send_file full_path
+    else
+        raise Sinatra::NotFound
+    end
   end
 
   get %r{/(.*)} do
@@ -617,5 +675,17 @@ class ShowOff < Sinatra::Application
         data
       end
     end
+  end
+
+  not_found do
+    # Why does the asset path start from cwd??
+    @asset_path.slice!(/^./)
+    @env = request.env
+    erb :'404'
+  end
+
+  at_exit do
+    viewstats = File.new("viewstats.json", "w")
+    viewstats.write @@counter.to_json
   end
 end

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1,6 +1,6 @@
 @media screen {
   body {
-			font-size: 100%;
+      font-size: 100%;
       font-family: "Gill Sans", Helvetica, Arial, sans-serif;
       background:#333;
       overflow:hidden;
@@ -386,6 +386,18 @@ a.fg-button { float:left; }
 
 #preshow_timer {
   bottom: 0px;
+}
+
+#download h1 {
+  font-size: 3em;
+}
+ul#downloads {
+    margin-left:  20%;
+    font-size: large;
+    list-style-type: disc;
+}
+ul#downloads li {
+    margin: 0.5em;
 }
 
 /** Print **/

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -47,6 +47,9 @@ function setupPreso(load_slides, prefix) {
 		bind('tap', swipeLeft).         // next
 		bind('swipeleft', swipeLeft).   // next
 		bind('swiperight', swipeRight); // prev
+
+  // start analytics counter
+  startCounter()
 }
 
 function loadSlides(load_slides, prefix) {
@@ -297,7 +300,6 @@ function showIncremental(incr)
 
 function prevStep()
 {
-
 	var event = jQuery.Event("showoff:prev");
 	$(currentSlide).find(".content").trigger(event);
 	if (event.isDefaultPrevented()) {
@@ -812,4 +814,24 @@ function StyleListMenuItem(t)
 }
 /********************
  End Style-Picker Code
+ ********************/
+
+
+/********************
+ Analytics Code
+ ********************/
+
+function startCounter()
+{
+  // the download enabler relies on zero based counting.
+  var counter = function() {
+		$.get("/counter", { page: slidenum } );
+		countTimer = setTimeout(counter, 1000);
+	}
+	countTimer = setTimeout(counter, 1000);
+}
+
+
+/********************
+ End Analytics Code
  ********************/

--- a/views/404.erb
+++ b/views/404.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <%= erb :header %>
+</head>
+
+<body id="download">
+
+    <div id="preso">
+        <h1>File Not Found!</h1>
+        <h2><%= @env['REQUEST_PATH'] %>
+    </div>
+    <div id="footer">
+        <span id="debugInfo"></span>
+    </div>
+</body>
+</html>

--- a/views/download.erb
+++ b/views/download.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <%= erb :header_mini %>
+</head>
+
+<body id="download">
+
+    <div id="preso">
+        <h1>File Downloads for <%= @title %></h1>
+        
+        <ul id="downloads">
+            <% if @downloads %>
+                <% @downloads.sort.map do |key, value| %>
+                    <% enabled, file, title = value %>
+                    <% if enabled %>
+                        <li><a href="/file/_files/<%= file %>">Slide <%= key %>: <%= title %>/<%= file %></a></li>
+                    <% end %>
+                <% end %>
+            <% end %>
+            
+        </ul>
+    </div>
+    <div id="footer">
+        <span id="debugInfo"></span>
+    </div>
+</body>
+</html>

--- a/views/header_mini.erb
+++ b/views/header_mini.erb
@@ -1,0 +1,19 @@
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title><%= @title %></title>
+
+  <meta name="viewport" content="width=device-width"/>
+
+  <link rel="stylesheet" href="<%= @asset_path %>css/reset.css" type="text/css"/>
+  <link rel="stylesheet" href="<%= @asset_path %>css/showoff.css" type="text/css"/>
+
+  <link type="text/css" href="<%= @asset_path %>css/fg.menu.css" media="screen" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
+
+  <% css_files.each do |css_file| %>
+    <% alternate = ShowOffUtils.default_style?(css_file) ? '' : 'alternate ' %>
+    <link rel="stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
+  <% end %>
+
+  <% js_files.each do |js_file| %>
+    <script type="text/javascript" src="<%= @asset_path %>file/<%= js_file %>"></script>
+  <% end %>


### PR DESCRIPTION
downloads
- Makes a download page for the presentation available on /download
- Allows downloadable files to be added via a tag in the slide:
  
  .download file.tar.gz
- The file must be in the _files directory
- The file will be available for download once the instructor has spent more than a second on the slide immediately following the slide with the .download tag
- Viewing by the instructor is defined as HTTP requestor of localhost
- Available for download means a URL is listed. This does not _prevent_ file downloads. This allows the instructor to share URLs prior to them being listed, if needed. However, if we decide that it's appropriate, I can verify permissions and prevent non-available files from being downloaded.
- A 404 page is provided

Analytics
- As part of the download functionality, I also implemented rudimentary analytics.
- This provides a simple number of seconds spent on page counter.
- The stats are available in the viewstats.json file after stopping the showoff server.
- Stats are a hash keyed off slide number (zero indexed)
- Stats provide remote host and seconds per page
