### PR TITLE
Eliminate warning when running help

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -685,7 +685,9 @@ class ShowOff < Sinatra::Application
   end
 
   at_exit do
-    viewstats = File.new("viewstats.json", "w")
-    viewstats.write @@counter.to_json
+    if defined?(@@counter)
+      viewstats = File.new("viewstats.json", "w")
+      viewstats.write @@counter.to_json
+    end
   end
 end


### PR DESCRIPTION
Added a check for the existance of @@counter before saving it to disk.
