### PR TITLE
Can now have multiple downloads per slide

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -289,9 +289,15 @@ class ShowOff < Sinatra::Application
 
       raw      = container.text
       fixed    = raw.gsub(/^\.download ?/, '')
+      
+      # first create the data structure
+      # [ enabled, slide name, [array, of, files] ]
+      @@downloads[seq] = [ false, name, [] ]
 
-      # [ enabled, path, slide name ]
-      @@downloads[seq] = [ false, fixed, name ]
+      fixed.each { |file|
+        # then push each file onto the list
+        @@downloads[seq][2].push(file)
+      }
 
       container.remove
     end

--- a/views/download.erb
+++ b/views/download.erb
@@ -13,10 +13,13 @@
         
         <ul id="downloads">
             <% if @downloads %>
+                <%# [ enabled, slide name, [array, of, files] ] %>
                 <% @downloads.sort.map do |key, value| %>
-                    <% enabled, file, title = value %>
+                    <% enabled, title, files = value %>
                     <% if enabled %>
-                        <li><a href="/file/_files/<%= file %>">Slide <%= key %>: <%= title %>/<%= file %></a></li>
+                        <% files.each do |file| %>
+                          <li><a href="/file/_files/<%= file %>">Slide <%= key %>: <%= title %>/<%= file %></a></li>
+                        <% end %>
                     <% end %>
                 <% end %>
             <% end %>


### PR DESCRIPTION
This patch allows you to use multiple .download tags on a single slide.
