### PR TITLE
Analytics

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -538,6 +538,25 @@ class ShowOff < Sinatra::Application
         end
       end
     end
+    
+    def stats(static=false)
+      if request.env['REMOTE_HOST'] == 'localhost'
+        # the presenter should have full stats
+        @counter = @@counter
+      end
+      
+      @all = Hash.new
+      @@counter.each do |slide, stats|
+        @all[slide] = 0
+        stats.map { |host, count| @all[slide] += count }
+      end
+      
+      # most and least five viewed slides
+      @least = @all.sort_by {|slide, time| time}[0..4]
+      @most = @all.sort_by {|slide, time| -time}[0..4]
+      
+      erb :stats
+    end
 
     def pdf(static=true)
       @slides = get_slides_html(static, true)

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -388,6 +388,12 @@ a.fg-button { float:left; }
   bottom: 0px;
 }
 
+/* downloads page */
+/* we want scrolls! */
+body#download {
+  overflow:auto;
+  height: auto;
+}
 #download h1 {
   font-size: 3em;
 }
@@ -399,6 +405,99 @@ ul#downloads {
 ul#downloads li {
     margin: 0.5em;
 }
+
+/**********************
+ ***   stats page   ***
+ **********************/
+/* we want scrolls! */
+body#stats {
+  overflow:auto;
+  height: auto;
+}
+
+/* apply some nifty rounding styles to the row */
+#stats div.row {
+  position: relative;
+  margin: 0.25em 1em;
+  padding: 0.1em;
+  background-color: #dfdfdf;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -khtml-border-radius: 5px;
+  border-radius: 5px;
+}
+/* and to the bar inside the row */
+#stats div.bar {
+  height: 1.25em;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -khtml-border-radius: 5px;
+  border-radius: 5px;
+}
+/* position the label to the top left and time to the top right */
+#stats div.row span.label {
+  position: absolute;
+  top: 0.15em;
+  left: 0.25em;
+}
+#stats div.time {
+  position: absolute;
+  top: 0.15em;
+  right: 0.25em;
+}
+
+/* style all three boxes */
+#stats div#least,
+#stats div#most,
+#stats div#all {
+  width: 45%;
+  border: 1px solid black;
+  -moz-border-radius: 1em;
+  -webkit-border-radius: 1em;
+  -khtml-border-radius: 1em;
+  border-radius: 1em;
+}
+
+/* least box */
+#stats div#least {
+  float: left;
+  margin-left: 3%;}
+#stats div#least div.bar {
+  background: #f5f56f;
+}
+
+/* most box */
+#stats div#most {
+  float: right;
+  margin-right: 3%;
+}
+#stats div#most div.bar {
+  background: #f45f5f;
+}
+
+/* listing of all stats */
+#stats div#all {
+  clear: both;
+  position: relative;
+  top: 3em;
+  margin: 0 3% 5em 3%;
+  width: 94%;
+}
+#stats div#all div.bar {
+  background: #66b366;
+}
+
+/* detail view */
+#stats div#all div.detail {
+  margin: 0 5em 0 1em;
+}
+#stats div#all div.detail div.bar {
+  background: #8484dd;
+}
+/**********************
+ *** end stats page ***
+ **********************/
+
 
 /** Print **/
 @media print {

--- a/views/header_mini.erb
+++ b/views/header_mini.erb
@@ -8,6 +8,8 @@
 
   <link type="text/css" href="<%= @asset_path %>css/fg.menu.css" media="screen" rel="stylesheet" />
   <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
+  
+  <script type="text/javascript" src="<%= @asset_path %>js/jquery-1.4.2.min.js"></script>
 
   <% css_files.each do |css_file| %>
     <% alternate = ShowOffUtils.default_style?(css_file) ? '' : 'alternate ' %>

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -21,27 +21,31 @@
         
         <div id="least">
           <h3>Least viewed slides</h3>
-          <% max = @least.sort.reverse[2][1].to_f %>
-          <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
-          <% @least.each do |slide, time| %>
-            <div class="row">
-              <span class="label">Slide <%= slide %>:</span>
-              <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
-              <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
-            </div>
+          <% if @least.size > 0 %>
+            <% max = @least.sort_by {|slide, time| -time}[0][1].to_f %>
+            <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
+            <% @least.each do |slide, time| %>
+              <div class="row">
+                <span class="label">Slide <%= slide %>:</span>
+                <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
+                <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
+              </div>
+            <% end %>
           <% end %>
         </div>
         
         <div id="most">
           <h3>Most viewed slides</h3>
-          <% max = @most[0][1].to_f %>
-          <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
-          <% @most.each do |slide, time| %>
-            <div class="row">
-              <span class="label">Slide <%= slide %>:</span>
-              <div class="bar" style="width: <%= (time/max)*100 %>%;"> :</div>
-              <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
-            </div>
+          <% if @least.size > 0 %>
+            <% max = @most[0][1].to_f %>
+            <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
+            <% @most.each do |slide, time| %>
+              <div class="row">
+                <span class="label">Slide <%= slide %>:</span>
+                <div class="bar" style="width: <%= (time/max)*100 %>%;"> :</div>
+                <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
+              </div>
+            <% end %>
           <% end %>
         </div>
         

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -1,0 +1,72 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <%= erb :header_mini %>
+    
+    <script type="text/javascript">
+        $(document).ready(function(){
+            $("#stats div#all div.detail").hide();
+            $("#stats div#all div.row").click(function() { 
+                $(this).find("div.detail").slideToggle("fast");
+            });
+        });
+    </script>
+</head>
+
+<body id="stats">
+    <div id="preso">
+        <h1>Viewing Statistics</h1>
+        
+        <div id="least">
+          <h3>Least viewed slides</h3>
+          <% max = @least.sort.reverse[2][1].to_f %>
+          <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
+          <% @least.each do |slide, time| %>
+            <div class="row">
+              <span class="label">Slide <%= slide %>:</span>
+              <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
+              <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
+            </div>
+          <% end %>
+        </div>
+        
+        <div id="most">
+          <h3>Most viewed slides</h3>
+          <% max = @most[0][1].to_f %>
+          <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
+          <% @most.each do |slide, time| %>
+            <div class="row">
+              <span class="label">Slide <%= slide %>:</span>
+              <div class="bar" style="width: <%= (time/max)*100 %>%;"> :</div>
+              <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
+            </div>
+          <% end %>
+        </div>
+        
+        <div id="all">
+          <h3>All slides</h3>
+          <%# We reuse the max value calculated from the above step. %>
+          <% @all.sort.map do |slide, time| %>
+              <div class="row">
+              <span class="label">Slide <%= slide %>:</span>
+              <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
+              <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
+              <% if @counter %>
+                <div class="detail">
+                  <% @counter[slide].each do |host, count| %>
+                    <div class="row">
+                      <span class="label"><%= host %>:</span>
+                      <div class="bar" style="width: <%= (count/max)*100 %>%;"> </div>
+                      <div class="time"><%= Time.at(count).gmtime.strftime(timestr) %></div>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>  
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This presents a view of the current stats at /stats

The instructor can view a breakdown of who (by hostname) is looking
spending time looking at which pages. Everyone else just gets the
sum of all students.

This does not read in time from last presentation, only from the
current, since you invoked showoff serve for the last time. You should
still yank viewstats.json and save it for later processing.

Please note that the instructor's viewing is not recorded, so you will
see a mostly empty page if you load it up without having viewed the
slides with a computer that is not the instructor's.
