### PR TITLE
Properly parses styles in .notes/.handouts

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -278,7 +278,7 @@ class ShowOff < Sinatra::Application
       container = doc.css("p.#{mark}").first
       return unless container
 
-      raw      = container.text
+      raw      = container.inner_html
       fixed    = raw.gsub(/^\.#{mark} ?/, '')
       markdown = Tilt[:markdown].new { fixed }.render
 


### PR DESCRIPTION
Previous to this patch, showoff would throw away all html after
processing markdown. So only text gets included in .notes/.handouts.

I don't know why the markdown processor needs to be invoked twice,
but that's a battle for another day.
