### PR TITLE
Initial support for .instructor tag

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -269,7 +269,7 @@ class ShowOff < Sinatra::Application
 
     def update_special_content(content, seq, name)
       doc = Nokogiri::HTML::DocumentFragment.parse(content)
-      %w[notes handouts solguide].each { |mark|  update_special_content_mark(doc, mark) }
+      %w[notes handouts instructor solguide].each { |mark|  update_special_content_mark(doc, mark) }
       update_download_links(doc, seq, name)
       doc.to_html
     end
@@ -278,12 +278,17 @@ class ShowOff < Sinatra::Application
       container = doc.css("p.#{mark}").first
       return unless container
 
-      raw      = container.inner_html
-      fixed    = raw.gsub(/^\.#{mark} ?/, '')
-      markdown = Tilt[:markdown].new { fixed }.render
+      # only allow localhost to print the instructor guide
+      if mark == 'instructor' and request.env['REMOTE_HOST'] != 'localhost'
+        container.remove
+      else
+        raw      = container.inner_html
+        fixed    = raw.gsub(/^\.#{mark} ?/, '')
+        markdown = Tilt[:markdown].new { fixed }.render
 
-      container.name       = 'div'
-      container.inner_html = markdown
+        container.name       = 'div'
+        container.inner_html = markdown
+      end
     end
     private :update_special_content_mark
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -232,7 +232,7 @@ h3 { font-size: 2em; }
 
 pre { margin: 1em 40px; padding: .25em; }
 
-.notes, .handouts, .solguide { display: none }
+.notes, .handouts, .instructor, .solguide { display: none }
 .hidden { position:absolute; top:0; left:-9999px; width:1px; height:1px; overflow:hidden; }
 .buttonNav { display: none }
 .offscreen { position:absolute; top:0; left:-9999px; overflow:hidden; }


### PR DESCRIPTION
This allows the use of the instructor tag.

This will only display the contents of that tag when localhost prints
the /onepage handler. For the time being, it simply suppresses the
output completely. My next revision, when I get time for it, will be to
add new endpoints so that we can print both an instructor guide and a
solutions manual. This will allow authors to use the tag without
buggering up their output though.

Expect the new endpoints in the next few weeks, but I need to get
Extending and the LMS up and running first.
