### PR TITLE
Added stats & download as popup menus

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -501,6 +501,25 @@ body#stats {
  *** end stats page ***
  **********************/
 
+/**********************
+ ** presenter popups **
+ **********************/
+.tipsy-inner { text-align: left; max-width: 500px; }
+.tipsy-inner h1 { font-size: 1.5em; }
+.tipsy-inner h2 { font-size: 1.35em; }
+.tipsy-inner h3 { font-size: 1.25em; }
+.tipsy-inner a { color: #0d8dfd; }
+.tipsy-inner a:hover { color: #04ffff; }
+
+.tipsy-inner #stats { min-width: 450px; }
+.tipsy-inner #stats .row { color: black; }
+.tipsy-inner #stats #all { max-height: 325px; overflow: auto; }
+
+.tipsy-inner ul#downloads { font-size: 1em; margin-left: 0.25em; }
+/************************
+ * end presenter popups *
+ ************************/
+
 
 /** Print **/
 @media print {

--- a/public/css/tipsy.css
+++ b/public/css/tipsy.css
@@ -1,0 +1,26 @@
+.tipsy { font-size: 10px; position: absolute; padding: 5px; z-index: 100000; }
+  .tipsy-inner { background-color: #000; color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
+
+  /* Rounded corners */
+  .tipsy-inner { border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px; }
+  
+  /* Uncomment for shadow */
+  /*.tipsy-inner { box-shadow: 0 0 5px #000000; -webkit-box-shadow: 0 0 5px #000000; -moz-box-shadow: 0 0 5px #000000; }*/
+  
+  .tipsy-arrow { position: absolute; width: 0; height: 0; line-height: 0; border: 5px dashed #000; }
+  
+  /* Rules to colour arrows */
+  .tipsy-arrow-n { border-bottom-color: #000; }
+  .tipsy-arrow-s { border-top-color: #000; }
+  .tipsy-arrow-e { border-left-color: #000; }
+  .tipsy-arrow-w { border-right-color: #000; }
+  
+	.tipsy-n .tipsy-arrow { top: 0px; left: 50%; margin-left: -5px; border-bottom-style: solid; border-top: none; border-left-color: transparent; border-right-color: transparent; }
+    .tipsy-nw .tipsy-arrow { top: 0; left: 10px; border-bottom-style: solid; border-top: none; border-left-color: transparent; border-right-color: transparent;}
+    .tipsy-ne .tipsy-arrow { top: 0; right: 10px; border-bottom-style: solid; border-top: none;  border-left-color: transparent; border-right-color: transparent;}
+  .tipsy-s .tipsy-arrow { bottom: 0; left: 50%; margin-left: -5px; border-top-style: solid; border-bottom: none;  border-left-color: transparent; border-right-color: transparent; }
+    .tipsy-sw .tipsy-arrow { bottom: 0; left: 10px; border-top-style: solid; border-bottom: none;  border-left-color: transparent; border-right-color: transparent; }
+    .tipsy-se .tipsy-arrow { bottom: 0; right: 10px; border-top-style: solid; border-bottom: none; border-left-color: transparent; border-right-color: transparent; }
+  .tipsy-e .tipsy-arrow { right: 0; top: 50%; margin-top: -5px; border-left-style: solid; border-right: none; border-top-color: transparent; border-bottom-color: transparent; }
+  .tipsy-w .tipsy-arrow { left: 0; top: 50%; margin-top: -5px; border-right-style: solid; border-left: none; border-top-color: transparent; border-bottom-color: transparent; }
+  

--- a/public/js/jquery.tipsy.js
+++ b/public/js/jquery.tipsy.js
@@ -1,0 +1,258 @@
+// tipsy, facebook style tooltips for jquery
+// version 1.0.0a
+// (c) 2008-2010 jason frame [jason@onehackoranother.com]
+// released under the MIT license
+
+(function($) {
+    
+    function maybeCall(thing, ctx) {
+        return (typeof thing == 'function') ? (thing.call(ctx)) : thing;
+    };
+    
+    function isElementInDOM(ele) {
+      while (ele = ele.parentNode) {
+        if (ele == document) return true;
+      }
+      return false;
+    };
+    
+    function Tipsy(element, options) {
+        this.$element = $(element);
+        this.options = options;
+        this.enabled = true;
+        this.fixTitle();
+    };
+    
+    Tipsy.prototype = {
+        show: function() {
+            var title = this.getTitle();
+            if (title && this.enabled) {
+                var $tip = this.tip();
+                
+                $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
+                $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
+                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
+                
+                var pos = $.extend({}, this.$element.offset(), {
+                    width: this.$element[0].offsetWidth,
+                    height: this.$element[0].offsetHeight
+                });
+                
+                var actualWidth = $tip[0].offsetWidth,
+                    actualHeight = $tip[0].offsetHeight,
+                    gravity = maybeCall(this.options.gravity, this.$element[0]);
+                
+                var tp;
+                switch (gravity.charAt(0)) {
+                    case 'n':
+                        tp = {top: pos.top + pos.height + this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+                        break;
+                    case 's':
+                        tp = {top: pos.top - actualHeight - this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+                        break;
+                    case 'e':
+                        tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - this.options.offset};
+                        break;
+                    case 'w':
+                        tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + this.options.offset};
+                        break;
+                }
+                
+                if (gravity.length == 2) {
+                    if (gravity.charAt(1) == 'w') {
+                        tp.left = pos.left + pos.width / 2 - 15;
+                    } else {
+                        tp.left = pos.left + pos.width / 2 - actualWidth + 15;
+                    }
+                }
+                
+                $tip.css(tp).addClass('tipsy-' + gravity);
+                $tip.find('.tipsy-arrow')[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
+                if (this.options.className) {
+                    $tip.addClass(maybeCall(this.options.className, this.$element[0]));
+                }
+                
+                if (this.options.fade) {
+                    $tip.stop().css({opacity: 0, display: 'block', visibility: 'visible'}).animate({opacity: this.options.opacity});
+                } else {
+                    $tip.css({visibility: 'visible', opacity: this.options.opacity});
+                }
+            }
+        },
+        
+        hide: function() {
+            if (this.options.fade) {
+                this.tip().stop().fadeOut(function() { $(this).remove(); });
+            } else {
+                this.tip().remove();
+            }
+        },
+        
+        fixTitle: function() {
+            var $e = this.$element;
+            if ($e.attr('title') || typeof($e.attr('original-title')) != 'string') {
+                $e.attr('original-title', $e.attr('title') || '').removeAttr('title');
+            }
+        },
+        
+        getTitle: function() {
+            var title, $e = this.$element, o = this.options;
+            this.fixTitle();
+            var title, o = this.options;
+            if (typeof o.title == 'string') {
+                title = $e.attr(o.title == 'title' ? 'original-title' : o.title);
+            } else if (typeof o.title == 'function') {
+                title = o.title.call($e[0]);
+            }
+            title = ('' + title).replace(/(^\s*|\s*$)/, "");
+            return title || o.fallback;
+        },
+        
+        tip: function() {
+            if (!this.$tip) {
+                this.$tip = $('<div class="tipsy"></div>').html('<div class="tipsy-arrow"></div><div class="tipsy-inner"></div>');
+                this.$tip.data('tipsy-pointee', this.$element[0]);
+            }
+            return this.$tip;
+        },
+        
+        validate: function() {
+            if (!this.$element[0].parentNode) {
+                this.hide();
+                this.$element = null;
+                this.options = null;
+            }
+        },
+        
+        enable: function() { this.enabled = true; },
+        disable: function() { this.enabled = false; },
+        toggleEnabled: function() { this.enabled = !this.enabled; }
+    };
+    
+    $.fn.tipsy = function(options) {
+        
+        if (options === true) {
+            return this.data('tipsy');
+        } else if (typeof options == 'string') {
+            var tipsy = this.data('tipsy');
+            if (tipsy) tipsy[options]();
+            return this;
+        }
+        
+        options = $.extend({}, $.fn.tipsy.defaults, options);
+        
+        function get(ele) {
+            var tipsy = $.data(ele, 'tipsy');
+            if (!tipsy) {
+                tipsy = new Tipsy(ele, $.fn.tipsy.elementOptions(ele, options));
+                $.data(ele, 'tipsy', tipsy);
+            }
+            return tipsy;
+        }
+        
+        function enter() {
+            var tipsy = get(this);
+            tipsy.hoverState = 'in';
+            if (options.delayIn == 0) {
+                tipsy.show();
+            } else {
+                tipsy.fixTitle();
+                setTimeout(function() { if (tipsy.hoverState == 'in') tipsy.show(); }, options.delayIn);
+            }
+        };
+        
+        function leave() {
+            var tipsy = get(this);
+            tipsy.hoverState = 'out';
+            if (options.delayOut == 0) {
+                tipsy.hide();
+            } else {
+                setTimeout(function() { if (tipsy.hoverState == 'out') tipsy.hide(); }, options.delayOut);
+            }
+        };
+        
+        if (!options.live) this.each(function() { get(this); });
+        
+        if (options.trigger != 'manual') {
+            var binder   = options.live ? 'live' : 'bind',
+                eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus',
+                eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur';
+            this[binder](eventIn, enter)[binder](eventOut, leave);
+        }
+        
+        return this;
+        
+    };
+    
+    $.fn.tipsy.defaults = {
+        className: null,
+        delayIn: 0,
+        delayOut: 0,
+        fade: false,
+        fallback: '',
+        gravity: 'n',
+        html: false,
+        live: false,
+        offset: 0,
+        opacity: 0.8,
+        title: 'title',
+        trigger: 'hover'
+    };
+    
+    $.fn.tipsy.revalidate = function() {
+      $('.tipsy').each(function() {
+        var pointee = $.data(this, 'tipsy-pointee');
+        if (!pointee || !isElementInDOM(pointee)) {
+          $(this).remove();
+        }
+      });
+    };
+    
+    // Overwrite this method to provide options on a per-element basis.
+    // For example, you could store the gravity in a 'tipsy-gravity' attribute:
+    // return $.extend({}, options, {gravity: $(ele).attr('tipsy-gravity') || 'n' });
+    // (remember - do not modify 'options' in place!)
+    $.fn.tipsy.elementOptions = function(ele, options) {
+        return $.metadata ? $.extend({}, options, $(ele).metadata()) : options;
+    };
+    
+    $.fn.tipsy.autoNS = function() {
+        return $(this).offset().top > ($(document).scrollTop() + $(window).height() / 2) ? 's' : 'n';
+    };
+    
+    $.fn.tipsy.autoWE = function() {
+        return $(this).offset().left > ($(document).scrollLeft() + $(window).width() / 2) ? 'e' : 'w';
+    };
+    
+    /**
+     * yields a closure of the supplied parameters, producing a function that takes
+     * no arguments and is suitable for use as an autogravity function like so:
+     *
+     * @param margin (int) - distance from the viewable region edge that an
+     *        element should be before setting its tooltip's gravity to be away
+     *        from that edge.
+     * @param prefer (string, e.g. 'n', 'sw', 'w') - the direction to prefer
+     *        if there are no viewable region edges effecting the tooltip's
+     *        gravity. It will try to vary from this minimally, for example,
+     *        if 'sw' is preferred and an element is near the right viewable 
+     *        region edge, but not the top edge, it will set the gravity for
+     *        that element's tooltip to be 'se', preserving the southern
+     *        component.
+     */
+     $.fn.tipsy.autoBounds = function(margin, prefer) {
+		return function() {
+			var dir = {ns: prefer[0], ew: (prefer.length > 1 ? prefer[1] : false)},
+			    boundTop = $(document).scrollTop() + margin,
+			    boundLeft = $(document).scrollLeft() + margin,
+			    $this = $(this);
+
+			if ($this.offset().top < boundTop) dir.ns = 'n';
+			if ($this.offset().left < boundLeft) dir.ew = 'w';
+			if ($(window).width() + $(document).scrollLeft() - $this.offset().left < margin) dir.ew = 'e';
+			if ($(window).height() + $(document).scrollTop() - $this.offset().top < margin) dir.ns = 's';
+
+			return dir.ns + (dir.ew ? dir.ew : '');
+		}
+	};
+    
+})(jQuery);

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -29,7 +29,43 @@ $(document).ready(function(){
   /* zoom slide to match preview size, then set up resize handler. */
   zoom();
   $(window).resize(function() { zoom(); });
+
+  // set up tooltips
+  $('#slaveWindow').tipsy({ offset: 5 });
+  $('#generatePDF').tipsy({ offset: 5 });
+  $('#onePage').tipsy({ offset: 5, gravity: 'ne' });
+
+  $('#stats').tipsy({ html: true, trigger: 'manual', gravity: 'ne', opacity: 0.9, offset: 5 });
+  $('#downloads').tipsy({ html: true, trigger: 'manual', gravity: 'ne', opacity: 0.9, offset: 5 });
+
+  $('#stats').click( function(e) {  popupLoader( $(this), '/stats', 'stats', e); });
+  $('#downloads').click( function(e) {  popupLoader( $(this), '/download', 'downloads', e); });
+
 });
+
+function popupLoader(elem, page, id, event)
+{
+  event.preventDefault();
+
+  if(elem.attr('open') == 'true') {
+    elem.attr('open', false)
+    elem.tipsy("hide");
+  }
+  else {
+    $.get(page, function(data) {
+      var content = '<div id="' + id + '">' + $(data).find('#wrapper').html() + '</div>';
+
+      console.log(content);
+
+      elem.attr('title', content);
+      elem.attr('open', true)
+      elem.tipsy("show");
+      setupStats();
+    });
+  }
+
+  return false;
+}
 
 function openSlave()
 {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -862,7 +862,7 @@ function StyleListMenuItem(t)
 
 
 /********************
- Analytics and Follower Code
+ Analytics and Follower
  ********************/
 
 function startPing()
@@ -894,5 +894,13 @@ function updateFollower()
 }
 
 /********************
- End Analytics and Follower Code
+ Stats page
  ********************/
+
+function setupStats()
+{
+  $("#stats div#all div.detail").hide();
+  $("#stats div#all div.row").click(function() {
+      $(this).find("div.detail").slideToggle("fast");
+  });
+}

--- a/views/download.erb
+++ b/views/download.erb
@@ -9,6 +9,7 @@
 <body id="download">
 
     <div id="preso">
+      <div id="wrapper">
         <h1>File Downloads</h1>
         
         <ul id="downloads">
@@ -25,6 +26,7 @@
             <% end %>
             
         </ul>
+      </div>
     </div>
 </body>
 </html>

--- a/views/header.erb
+++ b/views/header.erb
@@ -4,11 +4,13 @@
   <meta name="viewport" content="width=device-width"/>
 
   <link rel="stylesheet" href="<%= @asset_path %>css/reset.css" type="text/css"/>
-  <link rel="stylesheet" href="<%= @asset_path %>css/showoff.css" type="text/css"/>
 
   <link type="text/css" href="<%= @asset_path %>css/fg.menu.css" media="screen" rel="stylesheet" />
   <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
   <link type="text/css" href="<%= @asset_path %>css/sh_style.css" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>css/tipsy.css" rel="stylesheet" />
+
+  <link rel="stylesheet" href="<%= @asset_path %>css/showoff.css" type="text/css"/>
 
   <script type="text/javascript" src="<%= @asset_path %>js/jquery-1.4.2.min.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>js/jquery.cycle.all.js"></script>
@@ -16,6 +18,7 @@
   <script type="text/javascript" src="<%= @asset_path %>js/jquery.batchImageLoad.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>js/jquery.parsequery.min.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>js/jquery.doubletap-0.1.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>js/jquery.tipsy.js"></script>
 
   <script type="text/javascript" src="<%= @asset_path %>js/fg.menu.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>js/showoff.js"></script>

--- a/views/header_mini.erb
+++ b/views/header_mini.erb
@@ -10,6 +10,7 @@
   <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
   
   <script type="text/javascript" src="<%= @asset_path %>js/jquery-1.4.2.min.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>js/showoff.js"></script>
 
   <% css_files.each do |css_file| %>
     <% alternate = ShowOffUtils.default_style?(css_file) ? '' : 'alternate ' %>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -34,9 +34,11 @@
       Source: <span id="slideFile"></span>
     </div>
     <span id="links">
-      <a href="javascript:openSlave();">Open Slave Window</a>
-      <a href="/pdf">Generate PDF</a>
-      <a href="/onepage">Single Page</a>
+      <a id="stats" href="/stats" target="_showoffchild">Viewing Statistics</a>
+      <a id="downloads" href="/download" target="_showoffchild">Downloads</a>
+      <a id="slaveWindow" href="javascript:openSlave();" title="Open a slave window or reconnect to existing slave window.">Open Slave Window</a>
+      <a id="generatePDF" href="/pdf" title="Call out to wkhtmltopdf to generate a PDF.">Generate PDF</a>
+      <a id="onePage" href="/onepage" title="Load the single page view. Useful for printing.">Single Page</a>
     </span>
   </div>
 

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -6,17 +6,13 @@
     <%= erb :header_mini %>
     
     <script type="text/javascript">
-        $(document).ready(function(){
-            $("#stats div#all div.detail").hide();
-            $("#stats div#all div.row").click(function() { 
-                $(this).find("div.detail").slideToggle("fast");
-            });
-        });
+        $(document).ready(function(){ setupStats(); });
     </script>
 </head>
 
 <body id="stats">
     <div id="preso">
+      <div id="wrapper">
         <h1>Viewing Statistics</h1>
         
         <div id="least">
@@ -71,6 +67,7 @@
             </div>
           <% end %>  
         </div>
+      </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
The stats & download views are loaded dynamically, so they'll be
reloaded each time you hit them. Click the button to open, click again
to close.

It gracefully degrades in the wonky condition in which js is turned off,
even if the rest of showoff is über reliant on js.

You can right click on the button and open in new window to actually get
a new window/tab. You can right click on the files listed to get a link
to the file instead of downloading it. Etc.
