### PR TITLE
Ad hoc file sharing

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -420,6 +420,10 @@ subdirectory of your presentation.
 Once the instructor has viewed the next slide in your presentation, the file listed here will
 be available to download on the <tt>/download</tt> page.
 
+To share files on an ad-hoc basis, the instructor can simply drop files into <tt>_files/share</tt>.
+All files existing in this directory will be listed when students hit the download page. Showoff
+does not need to be restarted, even if you drop files in here during a presentation.
+
 = Editor integration
 
 The "add slide" feature can allow you to add the necessary boilerplate from your editor.  If you are using vim, you can

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -539,7 +539,10 @@ class ShowOff < Sinatra::Application
     end
 
     def download(static=false)
-      @downloads = @@downloads
+      shared = Dir.glob("#{settings.pres_dir}/_files/share/*").map { |path| File.basename(path) }
+      # We use the icky -999 magic index because it has to be comparable for the view sort
+      @downloads = { -999 => [ true, 'Shared Files', shared ] }
+      @downloads.merge! @@downloads
       erb :download
     end
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -466,6 +466,24 @@ body#stats {
 .tipsy-inner a { color: #0d8dfd; }
 .tipsy-inner a:hover { color: #04ffff; }
 
+.tipsy-inner p.newpage { text-align: right; padding-bottom: 0.25em; }
+.tipsy-inner p.newpage a {
+  color: white;
+  padding: 0.25em;
+  text-decoration: none;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -khtml-border-radius: 5px;
+  border-radius: 5px;
+  border: 1px solid black;
+}
+.tipsy-inner p.newpage a:hover {
+  font-weight: bold;
+  background-color: #222;
+  border: 1px solid white;
+}
+
+
 .tipsy-inner #stats { min-width: 450px; }
 .tipsy-inner #stats .row { color: black; }
 .tipsy-inner #stats #all { max-height: 325px; overflow: auto; }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -71,6 +71,7 @@ $(document).ready(function(){
 
 function popupLoader(elem, page, id, event)
 {
+  var title = elem.attr('title');
   event.preventDefault();
 
   if(elem.attr('open') == 'true') {
@@ -79,7 +80,8 @@ function popupLoader(elem, page, id, event)
   }
   else {
     $.get(page, function(data) {
-      var content = '<div id="' + id + '">' + $(data).find('#wrapper').html() + '</div>';
+      var link = '<p class="newpage"><a href="' + page + '" target="_new">Open in new page...</a>';
+      var content = '<div id="' + id + '">' + $(data).find('#wrapper').html() + link + '</div>';
 
       console.log(content);
 

--- a/views/download.erb
+++ b/views/download.erb
@@ -19,7 +19,11 @@
                     <% enabled, title, files = value %>
                     <% if enabled %>
                         <% files.each do |file| %>
-                          <li><a href="/file/_files/<%= file %>">Slide <%= key %>: <%= title %>/<%= file %></a></li>
+                          <% if key == -999 %>
+                            <li><a href="/file/_files/share/<%= file %>"><%= title %>/<%= file %></a></li>
+                          <% else %>
+                            <li><a href="/file/_files/<%= file %>">Slide <%= key %>: <%= title %>/<%= file %></a></li>
+                          <% end %>
                         <% end %>
                     <% end %>
                 <% end %>


### PR DESCRIPTION
To share files on an ad-hoc basis, the instructor can simply drop files
into `_files/share`. All files existing in this directory will be listed
when students hit the download page. Showoff does not need to be restarted,
even if you drop files in here during a presentation.
