### PR TITLE
Clicking on menus now pauses the remote follower

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -14,6 +14,9 @@ $(document).ready(function(){
 			if ($(this).next().is('ul')) {
 				$(this).next().toggle()
 			} else {
+				// pause follow mode for 30 seconds
+				resetModeTimer();
+
 				gotoSlide($(this).attr('rel'))
 				try { slaveWindow.gotoSlide($(this).attr('rel')) } catch (e) {}
 				postSlide()


### PR DESCRIPTION
Prior to this, if the presenter had dropped into remote mode, then you
clicked on a slide in the menu, it wouldn't change reliably.
