### PR TITLE
Add fix so that we can access presenter section on ruby 1.9.3

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -462,7 +462,7 @@ class ShowOff < Sinatra::Application
     def valid_key?(try)
       if not settings.showoff_config.has_key? 'presenter key'
         # if no key is set, then default to allowing access to localhost
-        return request.env['REMOTE_HOST'] == 'localhost'
+        return request.ip == '127.0.0.1'
       else
         return settings.showoff_config['presenter key'] == try
       end


### PR DESCRIPTION
If you tried to use ruby 1.9.3 and access the presenter area the REMOTE_HOST check would always fail, fixed so it works on 1.8.7 and 1.9.3 
