### PR TITLE
Pass :bind to Showoff.run! otherwise it only listens on localhost

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -128,7 +128,7 @@ If a presenter key is enabled, append ?key=<key> to the presenter url.
 -------------------------
 
 "
-    ShowOff.run! :host => options[:h], :port => options[:p].to_i, :pres_file => options[:f], :pres_dir => args[0], :verbose => options[:verbose]
+    ShowOff.run! :host => options[:h], :port => options[:p].to_i, :pres_file => options[:f], :pres_dir => args[0], :verbose => options[:verbose], :bind => options[:h]
   end
 end
 


### PR DESCRIPTION
When using a recent sinatra gem, showoff binds to `localhost` even if `-h` is specified. This patch changes the binding setting to use the value of the host specified with `-h`. This allows to launch it with `-h 0.0.0.0` for example.
