### PR TITLE
Wip/supplemental materials

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -266,6 +266,9 @@ class ShowOff < Sinatra::Application
         result.gsub!("~~~SECTION:MINOR~~~", @section_minor.to_s)
       end
 
+      # scan for pagebreak tags. Should really only be used for handout notes or supplemental materials
+      result.gsub!("~~~PAGEBREAK~~~", '<div class="break">continued...</div>')
+
       # Now check for any kind of options
       content.scan(/(~~~CONFIG:(.*?)~~~)/).each do |match|
         result.gsub!(match[0], settings.showoff_config[match[1]]) if settings.showoff_config.key?(match[1])

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -237,7 +237,6 @@ class ShowOff < Sinatra::Application
         end
 
         # Apply the template to the slide and replace the key with content of the slide
-        # This should really be done before the md translation, but that alters the DOM somehow
         sl = process_content_for_replacements(template.gsub(/~~~CONTENT~~~/, slide.text))
         sl = Tilt[:markdown].new { sl }.render
         sl = update_p_classes(sl)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -543,13 +543,12 @@ class ShowOff < Sinatra::Application
 
     def onepage(static=false)
       @slides = get_slides_html(:static=>static)
-      @languages = @slides.scan(/<pre class=".*(?!sh_sourceCode)(sh_[\w-]+).*"/).uniq.map{ |w| "/sh_lang/#{w[0]}.min.js"}
+      #@languages = @slides.scan(/<pre class=".*(?!sh_sourceCode)(sh_[\w-]+).*"/).uniq.map{ |w| "/sh_lang/#{w[0]}.min.js"}
       erb :onepage
     end
 
     def supplemental(content, static=false)
       @slides = get_slides_html(:static=>static, :supplemental=>content)
-      @languages = @slides.scan(/<pre class=".*(?!sh_sourceCode)(sh_[\w-]+).*"/).uniq.map{ |w| "/sh_lang/#{w[0]}.min.js"}
       @wrapper_classes = ['supplemental']
       erb :onepage
     end
@@ -788,7 +787,7 @@ class ShowOff < Sinatra::Application
     end
 
     # this hasn't been set to anything remotely interesting for a long time now
-    @asset_path = '/'
+    @asset_path = nil
 
     if (what != "favicon.ico")
       if what == 'supplemental'

--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.8'
+SHOWOFF_VERSION = '0.9'

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -375,6 +375,7 @@ a.fg-button { float:left; }
     .supplemental .content > ul { font-size: 1em; }
 
 .supplemental img { max-width: 7in; }
+.supplemental .content > pre { font-size: 0.9em; }
 .supplemental ul { list-style: disc; margin-left: 1.25em !important; padding-left: inherit !important; }
 .supplemental .content table { font-size: 0.65em; } /* Ugly hack for tables, which never seem to scale properly. Ick */
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -346,6 +346,38 @@ a.fg-button { float:left; }
   bottom: 0px;
 }
 
+/**********************************
+ ***   supplemental materials   ***
+ **********************************/
+#slides.supplemental .slide {
+  max-height: inherit;
+  height: 9.75in;
+  padding: 0.5em;
+  width: 8.1in;
+}
+
+.supplemental h1 { font-family: 'Arvo'; }
+.supplemental h2,
+    .supplemental h3,
+    .supplemental h4,
+    .supplemental h5,
+    .supplemental h6 { font-family: 'PT Sans'; }
+
+.supplemental h1 { font-size: 2em; }
+.supplemental h2 { font-size: 1.5em; }
+.supplemental h3,
+    .supplemental h4,
+    .supplemental h5,
+    .supplemental h6 { font-size: 1.3em; text-align: left; }
+
+.supplemental .content > p,
+    .supplemental .content > ol,
+    .supplemental .content > ul { font-size: 1em; }
+
+.supplemental img { max-width: 7in; }
+.supplemental ul { list-style: disc; margin-left: 1.25em !important; padding-left: inherit !important; }
+.supplemental .content table { font-size: 0.65em; } /* Ugly hack for tables, which never seem to scale properly. Ick */
+
 /* downloads page */
 /* we want scrolls! */
 body#download {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -375,7 +375,8 @@ a.fg-button { float:left; }
     .supplemental .content > ul { font-size: 1em; }
 
 .supplemental img { max-width: 7in; }
-.supplemental .content > pre { font-size: 0.9em; }
+.supplemental .content > pre,
+  .supplemental .content > pre > code { font-size: 10pt; font-family: 'Courier New', Courier, monospace; }
 .supplemental ul { list-style: disc; margin-left: 1.25em !important; padding-left: inherit !important; }
 .supplemental .content table { font-size: 0.65em; } /* Ugly hack for tables, which never seem to scale properly. Ick */
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -350,8 +350,8 @@ a.fg-button { float:left; }
  ***   supplemental materials   ***
  **********************************/
 #slides.supplemental .slide {
-  max-height: inherit;
-  height: 9.75in;
+  max-height: none !important;
+  height: auto;
   padding: 0.5em;
   width: 8.1in;
 }
@@ -378,6 +378,8 @@ a.fg-button { float:left; }
 .supplemental .content > pre { font-size: 0.9em; }
 .supplemental ul { list-style: disc; margin-left: 1.25em !important; padding-left: inherit !important; }
 .supplemental .content table { font-size: 0.65em; } /* Ugly hack for tables, which never seem to scale properly. Ick */
+
+.supplemental .content div.break { font-size: small; font-style: italic; padding-bottom: 0.25em; border-bottom: 1px dashed black; }
 
 /* downloads page */
 /* we want scrolls! */
@@ -611,4 +613,7 @@ body#stats {
   pre, code {
     font-family: Monaco, monospace;
   }
+
+  /* page break and remove the preview styling */
+  .supplemental .content div.break { page-break-after: always; padding-bottom: 0; border-bottom: none; }
 }

--- a/public/js/onepage.js
+++ b/public/js/onepage.js
@@ -1,4 +1,4 @@
 function setupOnePage() {
-  sh_highlightDocument();
+  sh_highlightDocument('/js/sh_lang/', '.min.js');
   centerSlides($("#slides > .slide"))
 }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -103,8 +103,9 @@ function initializePresentation(prefix) {
 		slidesLoaded = true
 	}
 	setupSlideParamsCheck();
-        try {
-	    sh_highlightDocument(prefix+'/js/sh_lang/', '.min.js')
+
+  try {
+	    sh_highlightDocument('/js/sh_lang/', '.min.js')
 	} catch(e) {
 	    sh_highlightDocument();
 	}
@@ -429,7 +430,7 @@ function executeAnyCode()
   var $coffeeCode = $('.execute .sh_coffeescript code:visible')
   if ($coffeeCode.length > 0) {
       executeCoffee.call($coffeeCode);
-  } 
+  }
 }
 
 function debug(data)

--- a/views/header.erb
+++ b/views/header.erb
@@ -3,44 +3,44 @@
 
   <meta name="viewport" content="width=device-width; initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
 
-  <link rel="stylesheet" href="<%= @asset_path %>css/reset.css" type="text/css"/>
+  <link rel="stylesheet" href="<%= @asset_path %>/css/reset.css" type="text/css"/>
 
-  <link type="text/css" href="<%= @asset_path %>css/fg.menu.css" media="screen" rel="stylesheet" />
-  <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
-  <link type="text/css" href="<%= @asset_path %>css/sh_style.css" rel="stylesheet" />
-  <link type="text/css" href="<%= @asset_path %>css/tipsy.css" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>/css/fg.menu.css" media="screen" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>/css/theme/ui.all.css" media="screen" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>/css/sh_style.css" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>/css/tipsy.css" rel="stylesheet" />
 
-  <link rel="stylesheet" href="<%= @asset_path %>css/showoff.css" type="text/css"/>
+  <link rel="stylesheet" href="<%= @asset_path %>/css/showoff.css" type="text/css"/>
 
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery-1.4.2.min.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery.cycle.all.js"></script>
-	<script type="text/javascript" src="<%= @asset_path %>js/jquery-print.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery.batchImageLoad.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery.parsequery.min.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery.doubletap-0.1.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery.tipsy.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery-1.4.2.min.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.cycle.all.js"></script>
+	<script type="text/javascript" src="<%= @asset_path %>/js/jquery-print.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.batchImageLoad.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.parsequery.min.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.doubletap-0.1.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.tipsy.js"></script>
 
-  <script type="text/javascript" src="<%= @asset_path %>js/fg.menu.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/showoff.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/jTypeWriter.js"> </script>
-  <script type="text/javascript" src="<%= @asset_path %>js/sh_main.min.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/core.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/showoffcore.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/coffee-script.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/fg.menu.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/showoff.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/jTypeWriter.js"> </script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/sh_main.min.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/core.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/showoffcore.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/coffee-script.js"></script>
 
   <% if @languages %>
     <% @languages.each do |l| %>
-      <script type="text/javascript" src="<%= @asset_path %>js/<%= l %>"></script>
+      <script type="text/javascript" src="<%= @asset_path %>/js/<%= l %>"></script>
     <% end %>
   <% end %>
 
   <% css_files.each do |css_file| %>
     <% alternate = ShowOffUtils.default_style?(css_file) ? '' : 'alternate ' %>
-    <link rel="stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
+    <link rel="stylesheet" href="<%= @asset_path %>/file/<%= css_file %>" type="text/css"/>
   <% end %>
 
   <% js_files.each do |js_file| %>
-    <script type="text/javascript" src="<%= @asset_path %>file/<%= js_file %>"></script>
+    <script type="text/javascript" src="<%= @asset_path %>/file/<%= js_file %>"></script>
   <% end %>
 
   <script type="text/javascript">

--- a/views/header_mini.erb
+++ b/views/header_mini.erb
@@ -3,20 +3,20 @@
 
   <meta name="viewport" content="width=device-width"/>
 
-  <link rel="stylesheet" href="<%= @asset_path %>css/reset.css" type="text/css"/>
-  <link rel="stylesheet" href="<%= @asset_path %>css/showoff.css" type="text/css"/>
+  <link rel="stylesheet" href="<%= @asset_path %>/css/reset.css" type="text/css"/>
+  <link rel="stylesheet" href="<%= @asset_path %>/css/showoff.css" type="text/css"/>
 
-  <link type="text/css" href="<%= @asset_path %>css/fg.menu.css" media="screen" rel="stylesheet" />
-  <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
-  
-  <script type="text/javascript" src="<%= @asset_path %>js/jquery-1.4.2.min.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>js/showoff.js"></script>
+  <link type="text/css" href="<%= @asset_path %>/css/fg.menu.css" media="screen" rel="stylesheet" />
+  <link type="text/css" href="<%= @asset_path %>/css/theme/ui.all.css" media="screen" rel="stylesheet" />
+
+  <script type="text/javascript" src="<%= @asset_path %>/js/jquery-1.4.2.min.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/showoff.js"></script>
 
   <% css_files.each do |css_file| %>
     <% alternate = ShowOffUtils.default_style?(css_file) ? '' : 'alternate ' %>
-    <link rel="stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
+    <link rel="stylesheet" href="<%= @asset_path %>/file/<%= css_file %>" type="text/css"/>
   <% end %>
 
   <% js_files.each do |js_file| %>
-    <script type="text/javascript" src="<%= @asset_path %>file/<%= js_file %>"></script>
+    <script type="text/javascript" src="<%= @asset_path %>/file/<%= js_file %>"></script>
   <% end %>

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -20,7 +20,6 @@
     </script>
 
   <% else %>
-
     <% ['reset.css', 'showoff.css', 'theme/ui.all.css', 'sh_style.css', 'onepage.css'].each do |css_file| %>
       <link rel="stylesheet" href="<%= @asset_path %>css/<%= css_file %>" type="text/css"/>
     <% end %>
@@ -49,7 +48,7 @@
 </head>
 
 <body>
-<div id="slides">
+<div id="slides"<% if @wrapper_classes then %>class="<%= @wrapper_classes.join(' ') %>"<% end %> >
   <%= @slides %>
 </div>
 </body>

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -21,21 +21,21 @@
 
   <% else %>
     <% ['reset.css', 'showoff.css', 'theme/ui.all.css', 'sh_style.css', 'onepage.css'].each do |css_file| %>
-      <link rel="stylesheet" href="<%= @asset_path %>css/<%= css_file %>" type="text/css"/>
+      <link rel="stylesheet" href="<%= @asset_path %>/css/<%= css_file %>" type="text/css"/>
     <% end %>
     <% css_files.each do |css_file| %>
-      <link rel="stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
+      <link rel="stylesheet" href="<%= @asset_path %>/file/<%= css_file %>" type="text/css"/>
     <% end %>
 
     <% ['jquery-1.4.2.min.js', 'jquery-print.js', 'showoff.js', 'onepage.js', 'sh_main.min.js', 'core.js', 'showoffcore.js'].each do |js_file| %>
-      <script type="text/javascript" src="<%= @asset_path %>js/<%= js_file %>"></script>
+      <script type="text/javascript" src="<%= @asset_path %>/js/<%= js_file %>"></script>
     <% end %>
     <% js_files.each do |js_file| %>
-      <script type="text/javascript" src="<%= @asset_path %>file/<%= js_file %>"></script>
+      <script type="text/javascript" src="<%= @asset_path %>/file/<%= js_file %>"></script>
     <% end %>
     <% if @languages %>
       <% @languages.each do |l| %>
-        <script type="text/javascript" src="<%= @asset_path %>js<%= l %>"></script>
+        <script type="text/javascript" src="<%= @asset_path %>/js<%= l %>"></script>
       <% end %>
     <% end %>
     <script type="text/javascript">

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -4,8 +4,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
   <%= erb :header %>
-  <link rel="stylesheet" href="<%= @asset_path %>css/presenter.css" type="text/css"/>
-  <script type="text/javascript" src="<%= @asset_path %>js/presenter.js"></script>
+  <link rel="stylesheet" href="<%= @asset_path %>/css/presenter.css" type="text/css"/>
+  <script type="text/javascript" src="<%= @asset_path %>/js/presenter.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Fixes #34
## Add supplemental material handling

This is a somewhat haphazard fix, in my opinion, but doing it in a better way requires refactoring request routing. That needs to be done soon, very very soon, but that day is not today.

To use this, simply add a slide with the classes of 'supplemental' and whatever type of supplemental material it is.

For example:
  `<!SLIDE supplemental solutions>`

This can be included in the same file as the labs, so this means that we can make each lab, its corresponding guide page, and its solution all self contained.

To access the supplemental materials, simply browse to: http://<host>:9090/supplemental/<type>

For example: http://localhost:9090/supplemental/solutions
## Added special tags for automagically including counters
- `~~~SECTION:MAJOR~~~` translates to section counter
- `~~~SECTION:MINOR~~~` translates to auto resetting in-section counter

This means that we can now replace our Lab/Exercise/Solutions headers with macros, such as:
- `# Lab ~~~SECTION:MAJOR~~~.~~~SECTION:MINOR~~~: Lab Title`
## Added file inclusion tag

Include a tag like `~~~FILE:fundamentals-4.1-solution.pp:Puppet~~~` and it will be replaced with the contents of that file, wrapped in the proper HTML to display it as code, syntax highlighted with the classes provided. The general case is these two forms:
- `~~~FILE:<filename>:<space separated list of classes>~~~`
- `~~~FILE:<filename~~~`
## Added pagebreak tag support

Any place you'd like an explicit pagebreak, in either .handout notes or in supplemental materials, simply include the tag `~~~PAGEBREAK~~~`.

Supplemental materials will now display the entire content in the browser preview instead of the first page only. You will need to print to PDF in order to have an understanding of where pagebreaks, soft and hard, will occur.
