### PR TITLE
Add button for reporting issues

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -561,6 +561,7 @@ class ShowOff < Sinatra::Application
     end
 
     def presenter
+      @issues = settings.showoff_config['issues']
       erb :presenter
     end
 

--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.9.1'
+SHOWOFF_VERSION = '0.9.3'

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -410,6 +410,10 @@ ul#downloads li {
     margin: 0.5em;
 }
 
+span#issueUrl {
+  display: none;
+}
+
 /**********************
  ***   stats page   ***
  **********************/

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -34,6 +34,7 @@ $(document).ready(function(){
   $(window).resize(function() { zoom(); });
 
   // set up tooltips
+  $('#report').tipsy({ offset: 5 });
   $('#slaveWindow').tipsy({ offset: 5 });
   $('#generatePDF').tipsy({ offset: 5 });
   $('#onePage').tipsy({ offset: 5, gravity: 'ne' });
@@ -96,6 +97,13 @@ function popupLoader(elem, page, id, event)
   }
 
   return false;
+}
+
+function reportIssue() {
+  var slide  = $("span#slideFile").text();
+  var issues = $("span#issueUrl").text();
+  var link = issues + encodeURIComponent('Issue with slide: ' + slide);
+  window.open(link);
 }
 
 function openSlave()

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -4,7 +4,7 @@ require 'showoff/version'
 Gem::Specification.new do |s|
   s.name              = "showoff"
   s.version           = SHOWOFF_VERSION
-  s.date              = "2011-09-10"
+  s.date              = Date.today.to_s
   s.summary           = "The best damn presentation software a developer could ever love."
   s.homepage          = "http://github.com/schacon/showoff"
   s.email             = "schacon@gmail.com"
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   The idea is that you setup your slide files in section subdirectories and
   then startup the showoff server in that directory.  It will read in your
-  showoff.json file for which sections go in which order and then will give 
+  showoff.json file for which sections go in which order and then will give
   you a URL to present from.
   desc
 end

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -10,6 +10,8 @@
 
 <body>
 
+<span id="issueUrl"><%= @issues %></span>
+
 <div id="help">
   <table>
     <tr><td class="key">z, ?</td><td>toggle help (this)</td></tr>
@@ -31,6 +33,9 @@
     </div>
     <span id="links">
       <span class="desktop">
+        <% if @issues %>
+          <a id="report" href="javascript:reportIssue();" title="Report an issue with the current slide.">Report Issue With Slide</a>
+        <% end %>
         <a id="stats" href="/stats" target="_showoffchild">Viewing Statistics</a>
         <a id="downloads" href="/download" target="_showoffchild">Downloads</a>
         <a id="slaveWindow" href="javascript:openSlave();" title="Open a slave window or reconnect to existing slave window.">Open Slave Window</a>


### PR DESCRIPTION
If the key "issues" is present in showoff.json, then this will present a
button allowing the presenter to file a ticket from the presenter view.

The issues key should be set to a string that points to the ticketing
system. It will be appended with a URI encoded string indicating which
slide the problem is on. This string will then be opened as a URI in a
new window.
