### PR TITLE
Maintain a more robust slave window connnection

### DIFF
--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.9.3'
+SHOWOFF_VERSION = '0.9.4'

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -111,7 +111,8 @@ function openSlave()
   try {
     if(slaveWindow == null || typeof(slaveWindow) == 'undefined' || slaveWindow.closed){
         slaveWindow = window.open('/?ping=false' + window.location.hash);
-    } else {
+    }
+    else if(slaveWindow.location.hash != window.location.hash) {
       // maybe we need to reset content?
       slaveWindow.location.href = '/?ping=false' + window.location.hash;
     }
@@ -120,8 +121,13 @@ function openSlave()
     slaveWindow.presenterView = window;
   }
   catch(e) {
-    console.log('Slave window failed to open.');
+    console.log('Failed to open or connect slave window. Popup blocker?');
     console.log(e);
+  }
+
+  // Set up a maintenance loop to keep the connection between windows. I wish there were a cleaner way to do this.
+  if (typeof maintainSlave == 'undefined') {
+    maintainSlave = setInterval(openSlave, 1000);
   }
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -57,6 +57,10 @@ function setupPreso(load_slides, prefix) {
   // start pinging the server
   if(query.ping == 'false') mode = modeState.passive;
   startActionLoop();
+
+  // Make sure the slides always look right.
+  // Better would be dynamic calculations, but this is enough for now.
+  $(window).resize(function(){location.reload();});
 }
 
 function loadSlides(load_slides, prefix) {

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -38,7 +38,7 @@
         <% end %>
         <a id="stats" href="/stats" target="_showoffchild">Viewing Statistics</a>
         <a id="downloads" href="/download" target="_showoffchild">Downloads</a>
-        <a id="slaveWindow" href="javascript:openSlave();" title="Open a slave window or reconnect to existing slave window.">Open Slave Window</a>
+        <a id="slaveWindow" href="javascript:openSlave();" title="Open a slave window if your popup blocker prevented it.">Open Slave Window</a>
         <a id="generatePDF" href="/pdf" title="Call out to wkhtmltopdf to generate a PDF.">Generate PDF</a>
         <a id="onePage" href="/onepage" title="Load the single page view. Useful for printing.">Single Page</a>
       </span>


### PR DESCRIPTION
- Will auto reload when the page is resized
- Will automatically maintain slave window connection. You should never
  have to click the Slave Window button again, unless you're blocking my
  popups.
- You shouldn't really have to worry about window management at all
  anymore. Simply toss the slave viewer window wherever you want it and
  go.
