### PR TITLE
Calculate dependencies so this builds on old ruby

### DIFF
--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.9.5'
+SHOWOFF_VERSION = '0.9.5.1'

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -1,5 +1,6 @@
 $:.unshift File.expand_path("../lib", __FILE__)
 require 'showoff/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name              = "showoff"
@@ -24,6 +25,16 @@ Gem::Specification.new do |s|
   s.add_dependency      "gli",">= 1.3.2"
   s.add_dependency      "parslet"
   s.add_dependency      "htmlentities"
+
+  # both gems fail to build on Ruby 1.8.7, the default in older OS X
+  if RUBY_VERSION.to_f < 1.9
+    s.add_dependency      "redcarpet" < "3.0.0"
+    s.add_dependency      "nokogiri"  < "1.5.10"
+  else
+    s.add_dependency      "redcarpet"
+    s.add_dependency      "nokogiri"
+  end
+
   s.add_development_dependency "mg"
   s.description       = <<-desc
   ShowOff is a Sinatra web app that reads simple configuration files for a


### PR DESCRIPTION
Ruby 1.8.7 blows up on new versions of nokogiri and redcarpet, so
blacklist those version if we're building on old ruby.
