### PR TITLE
Initialize config to an empty hash

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -36,7 +36,7 @@ class ShowOff < Sinatra::Application
   set :pres_file, 'showoff.json'
   set :page_size, "Letter"
   set :pres_template, nil
-  set :showoff_config, nil
+  set :showoff_config, {}
   set :downloads, nil
   set :counter, nil
   set :current, 0


### PR DESCRIPTION
This restores the ability of Showoff to run in autodiscovery mode, i.e.
without a `showoff.json` file.
