### PR TITLE
More documentation cleanups

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -57,7 +57,7 @@ For example:
 This lets you keep the ability to emit an HTML document from your Markdown source
 file -- say, for a TextMate preview or a GitHub rendering
 
-== Markdown format
+== Markdown Format
 
 Showoff renders Markdown format as documented at http://daringfireball.net/projects/markdown/syntax.
 Extensions to the language are documented below.
@@ -82,7 +82,7 @@ Some useful styles for each slide are:
 
 Check out the example directory included to see examples of most of these.
 
-= Supplemental materials
+= Supplemental Materials
 
 Supplemental materials may be created by including <tt>supplemental</tt> and the name of a type
 in the <!SLIDE> styles. For example, you might have a slide like
@@ -103,54 +103,100 @@ it extraordinarily easy to reorder the presentation.
 Transitions can be supplied through the use of transition=tname on the !SLIDE
 definition, where tname is one of the following supported transitions:
 
-* blindX
-* blindY
-* blindZ
-* cover
-* curtainX
-* curtainY
-* fade
-* fadeZoom
-* growX
-* growY
-* none (this is the default)
-* scrollUp
-* scrollDown
-* scrollLeft
-* scrollRight
-* scrollHorz
-* scrollVert
-* shuffle
-* slideX
-* slideY
-* toss
-* turnUp
-* turnDown
-* turnLeft
-* turnRight
-* uncover
-* wipe
-* zoom
+- blindX
+- blindY
+- blindZ
+- cover
+- curtainX
+- curtainY
+- fade
+- fadeZoom
+- growX
+- growY
+- none (this is the default)
+- scrollUp
+- scrollDown
+- scrollLeft
+- scrollRight
+- scrollHorz
+- scrollVert
+- shuffle
+- slideX
+- slideY
+- toss
+- turnUp
+- turnDown
+- turnLeft
+- turnRight
+- uncover
+- wipe
+- zoom
 
 The transitions are provided by jQuery Cycle plugin. See http://www.malsup.com/jquery/cycle/browser.html to view the effects and http://www.malsup.com/jquery/cycle/adv2.html for how to add custom effects.
 
-= Language highlighting
+= Language Highlighting
 
-Showoff uses {shjs}[http://shjs.sourceforge.net/] to highlight code blocks.
-If you begin a code block with three @-signs followed by a
-{programming language name}[http://shjs.sourceforge.net/doc/documentation.html],
-that line will be stripped and the rest of the block will become sparkly
-and colorful.
+Showoff uses {shjs}[http://shjs.sourceforge.net/] to highlight code blocks. If you begin a
+code block with three @-signs followed by a programming language name, that line will be
+stripped and the rest of the block will become sparkly and colorful.
 
-    @@@ ruby
+    @@@ Ruby
     10.times { puts "Whee!" }
 
-Supported languages and instructions for adding support for new languages can be found at
-http://shjs.sourceforge.net/doc/documentation.html
+Supported languages include:
+
+- Bison
+- C
+- Caml
+- Changelog
+- Coffeescript
+- Cpp
+- Csharp
+- Css
+- Cucumber
+- Desktop
+- Diff
+- Erlang
+- Flex
+- Glsl
+- Haxe
+- Html
+- Ini
+- Java
+- Javascript
+- Javascript_dom
+- Latex
+- Ldap
+- Log
+- Lsm
+- M4
+- Makefile
+- Oracle
+- Pascal
+- Perl
+- Php
+- Prolog
+- Properties
+- Puppet
+- Puppet_output
+- Python
+- Ruby
+- Scala
+- Sh
+- Shell
+- Slang
+- Sml
+- Spec
+- Sql
+- Tcl
+- Xml
+- Xorg
+
+Instructions for adding support for new languages can be found at http://shjs.sourceforge.net/doc/documentation.html
 
 = Sections
 
-== Presenter notes:
+== Presenter Notes
 
 Surround presenter notes with <tt>~~SECTION:notes~~</tt> and <tt>~~ENDSECTION~~</tt> tags. It will
 display in the bottom section of the presenter view. The footer on the display window
@@ -177,12 +223,28 @@ Handout notes are best viewed by printing the <tt>/onepage</tt> view from your b
 be printed on a new page and handout notes will be included below the slide contents. Handout notes can
 contain any markup that the slide itself can.
 
-= Other tags
+= Other Tags
 
-[~~~SECTION:MAJOR~~~] This is the section major number. It is a counter that increments each time a subsection tag is encountered.
-[~~~SECTION:MINOR~~~] This is the section minor number. It is incremented each time it is used and reset each time a subsection tag is encountered.
-[~~~PAGEBREAK~~~] Just generates a <code><div class="break">continued...</div></code> HTML snippet.
-[~~~TOC~~~] Generates a Table of Contents with links to section titles. Some renderers (such as PrinceXML) are able to autonumber the table.
+[~~~SECTION:MAJOR~~~]
+  This is the section major number. It is a counter that increments each time a subsection tag is
+  encountered.
+
+[~~~SECTION:MINOR~~~]
+  This is the section minor number. It is incremented each time it is used and reset each time a
+  subsection tag is encountered.
+
+[~~~FILE:filename.ext~~~]
+[~~~FILE:filename.ext:filetype~~~]
+  Includes the content of a file in the <tt>_files</tt> directory on the slide as code. If the
+  optional <tt>filetype</tt> is included then the code block will be syntax highlighted appropriately.
+
+[~~~PAGEBREAK~~~]
+  Just generates a <code><div class="break">continued...</div></code> HTML snippet which is styled
+  as a hard page break in modern HTML rendering engines.
+
+[~~~TOC~~~]
+  Generates a Table of Contents using the subsection titles. Some renderers (such as
+  PrinceXML[http://www.princexml.com]) are able to autonumber the table with links to content.
 
 = Preshow
 
@@ -192,7 +254,7 @@ If you then press 'p' at the beginning of your presentation, it will prompt you 
 you start.  Then it will count down the time until then, flipping through your pictures to entertain the
 audience in the meantime.  Press 'p' again to stop, or wait until the timer runs out.
 
-= Download files
+= Download Files
 
 Add a line that starts with <tt>.download</tt> and contains the name of a file in the <tt>_files</tt>
 subdirectory of your presentation.
@@ -200,16 +262,19 @@ subdirectory of your presentation.
     .download file.tar.gz
 
 Once the instructor has viewed the next slide in your presentation, the file listed here will
-be available to download on the <tt>/download</tt> page.
+be available to download on the <tt>/download</tt> page. For example, if the file was referenced
+on page #42, then the file would be listed when the instructor advances to slide #43.
+
+<em>Note, this means only the *next* slide, not any subsequent slide.</em>
 
 To share files on an ad-hoc basis, the instructor can simply drop files into <tt>_files/share</tt>.
 All files existing in this directory will be listed when students hit the download page. Showoff
 does not need to be restarted, even if you drop files in here during a presentation.
 
 
-= Showing plain old markdown
+= Showing Plain Old Markdown
 
-If a markdown file has no !SLIDE keywords, then showoff will treat every line
+If a Markdown file has no !SLIDE keywords, then Showoff will treat every line
 beginning with a single hash -- i.e. every H1 -- as a new slide in "bullets"
 style. Remember that you can't specify classes or transitions in this mode,
 and as soon as you add one !SLIDE you need them everywhere.
@@ -432,9 +497,7 @@ as the last slide in that dir (use -u to avoid numbering). Without those, output
 stdout (useful for shelling out from your editor). You may also specify a source file to use for a code
 slide.
 
-=== options for add
-
-These options are specified *after* the command.
+Options are specified *after* the command.
 
 [<tt>-d, --dir=dir</tt>] Slide dir (where to put a new slide file)
 [<tt>-n, --name=basename</tt>] Slide name (name of the new slide file)
@@ -452,9 +515,7 @@ Create new showoff presentation
 
 This command helps start a new showoff presentation by setting up the proper directory structure for you.  It takes the directory name you would like showoff to create for you.
 
-=== options for create
-
-These options are specified *after* the command.
+Options are specified *after* the command.
 
 [<tt>-d, --slidedir=arg</tt>] sample slide directory name <i>( default: <tt>one</tt>)</i>
 [<tt>-n, --nosamples</tt>] Dont create sample slides

--- a/documentation/INSTALLATION.rdoc
+++ b/documentation/INSTALLATION.rdoc
@@ -12,12 +12,18 @@ and build the gem manually instead.
     $ gem build showoff.gemspec
     $ gem install showoff-<version>.gem
 
+Showoff is tested with Ruby 1.8.7, 1.9.3, and 2.0. It should install cleanly on these versions.
+
 = Requirements
 
-* Ruby and RubyGems
-* gems:
+* Ruby
+* RubyGems:
   * Sinatra (and thus Rack)
-  * BlueCloth
+  * Supported Markdown engine
+    - Redcarpet (default)
+    - BlueCloth
+    - Maruku
+    - rdiscount
   * Nokogiri
   * json
   * GLI

--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -8,15 +8,15 @@ markdown files for the slides you're presenting.
     $ cd (showoff-repo)
     $ showoff serve
 
-If you run 'showoff' in the example subdirectory of ShowOff itself, it will
+If you run Showoff in the example subdirectory of ShowOff itself, it will
 show an example presentation, so you can see what it's like.
 
-You can also run 'showoff serve' inside a section subdirectory. If there is no
+You can also run <tt>showoff serve</tt> inside a section subdirectory. If there is no
 <tt>showoff.json</tt> file then it will make its best guess, creating a presentation
 from all `.md` files in alphabetical order in the given (or current)
 directory.
 
-== Available URL paths
+== Available URL Paths
 
 Once the showoff server is running, you can connect to it via a standard modern
 web browser. The following URL paths are available for use by you and your audience.
@@ -31,8 +31,11 @@ web browser. The following URL paths are available for use by you and your audie
   presentation, including a full tree view of all slides and presenter notes underneath
   the slide itself. It will attempt to open a slave window that you can put on the
   projector. The slave window will follow along with the presenter window. If you have a
-  popup blocker running, the slave window may not open. There is a button on the presenter
-  view to manually open a new slave window.
+  popup blocker running, the slave window may not open. There is a button in the toolbar
+  to manually open a new slave window in this case.
+
+  If password protection is enabled, this view is often protected and you will need
+  to authenticate to view.
 
   If this path is opened by a secondary device, such as a mobile browser, then it can also
   control the presentation if enabled with the <tt>Enable Remote</tt>  button. Showoff
@@ -58,18 +61,27 @@ web browser. The following URL paths are available for use by you and your audie
 [http://localhost:9090/supplemental/$type-name]
   Showoff has the ability to include supplemental material that are defined by special
   slide types. This URL path will allow you and/or the audience to retrieve the
-  supplemental materials. Often used to generate printed material ahead of time rather
-  than during the presentation itself.
+  supplemental materials. This is most often used to generate printed material ahead
+  of time rather than during the presentation itself.
 
-== Presenter view tools
+== Presenter View Tools
 
 The presenter view is broken into several areas with tools that are mostly self explanatory. Nevertheless, I'll summarize their usage.
 
-=== Toolbar Buttons
+=== Toolbar
+
+This is the black toolbar across the top of the presenter view. It has several important
+tools that you should be familiar with.
+
+[Slide Name]
+  This is the name of the current slide. The name is derived from the filename that is
+  used to generate the slide, so is exponentially more useful than a slide number when
+  correlating slide content with the source file used to generate it.
 
 [Report Issue With Slide]
   If the <tt>showoff.json</tt> file contains an <tt>issues</tt> key then this button
-  will allow presenters to report problems with the slide currently being viewed.
+  will allow presenters to report problems with the slide currently being viewed
+  using the configured issue tracker.
 
 [Viewing Statistics]
   Drops down a menu of the viewer stats from the <tt>/stats</tt> URL path. Contains a
@@ -102,9 +114,18 @@ immediately jump to that slide.
 This contains a scaled down version of the current slide. It will attempt to size it to fit your screen
 and scale the contents as closely as possible. Several tools are attached to the bottom of this view.
 
-[Update Follower] Allow other viewers in <em>Follow Mode</em> to track your progress.
-[Enable Remote] Allow remote windows, including mobile devices, to control the presentation by opening the <tt>/presenter</tt> view.
-[Zoom] Zoom in and out of the preview.
+[Update Follower]
+  Allow other viewers in Follow Mode to track your progress.
+
+[Enable Remote]
+  Allow remote windows, including mobile devices, to control the presentation by
+  opening the presenter view. This button will glow yellow when Showoff is listening
+  for remote updates. Please see {Follow Mode}[#label-Follow+Mode] and
+  {Remote Control}[#label-Remote+Control] below
+  for more information.
+
+[Zoom]
+  Zoom in and out of the preview.
 
 === Presenter Notes
 
@@ -129,7 +150,59 @@ The following hotkeys are available for usage while viewing the slideshow.
 [b] Toggle screenblanker. Similar to pause, this will pause the presentation and slide the slide off screen.
 [s] Choose style. Pull open the style chooser menu. You can embed multiple styles (for example, style target at different screen sizes or audiences) and use this menu to choose the appropriate style.
 
-= Command line usage
+== Follow Mode
+
+The audience can choose to follow along with the presentation automatically, and the
+presenter may control the presentation in a few different ways. Showoff implements
+several strategies for keeping all views of the presentation in sync.
+
+[Audience Follow Mode]
+  If an audience member switches into follow mode by pressing the <tt>g</tt> hotkey, then
+  their browser will automatically change slides to follow along with the presentation.
+
+[Slave Window]
+  When the presenter changes slides from either the presenter view or the slave window
+  then the other view switches to match.
+
+[Remote Control]
+  If the presenter opens multiple presenter views, then Showoff tries to heuristically
+  guess which view should be the "controller" at any given time. This is most useful
+  when the presenter opens the presenter view on a mobile device for a remote control.
+
+  The presenter view will consider itself to be the authoritative source of the current
+  slide indicator as long as you are actively using it. When you have not pressed a key
+  for 30 seconds, it will also switch into Follow Mode and will track slide
+  updates from remotes. The on screen indicator below the slide preview will glow yellow
+  when it has switched into Follow Mode.
+
+== Remote Control
+
+Open the presenter view on a mobile device for a simplified remote control view of your
+presentation. You will get a slide preview, plus presentation notes. If you scroll down,
+you will also see the presentation tree and can navigate to any slide. If the main
+presenter is in Follow Mode, then it will track slide updates.
+
+To save battery, the Remote Control does not listen for slide updates. Instead, there
+is a manual <tt>Update</tt> button, which will request the current slide from the
+Showoff server and change to it.
+
+[Advance slide forward]
+  Tap on the slide, or swipe from right to left.
+
+[Return to a previous slide]
+  Swipe from left to right.
+
+[Update]
+  Press this button to quickly change to the current slide being displayed by the
+  Presenter view.
+
+[Update Follower]
+  Enable this toggle to act as a Remote Control. Disable it to navigate through the
+  slide deck without updating the slide being projected.
+
+<em>Warning, using the Remote Control will chew the hell out of your phone battery.</em>
+
+= Command Line Usage
 
 == <tt>showoff help [command]</tt>
 
@@ -147,8 +220,7 @@ Creates the Gemfile and config.ru file needed to push a showoff pres to heroku. 
 
 Generates a static version of your site and puts it in a gh-pages branch for static serving on GitHub.
 
-=== options for github
-These options are specified *after* the command.
+Options are specified *after* the command.
 
 [<tt>-f, --force</tt>] force overwrite of existing Gemfile/.gems and config.ru files if they exist
 [<tt>-g, --dotgems</tt>] Use older-style .gems file instead of bundler-style Gemfile
@@ -159,8 +231,7 @@ These options are specified *after* the command.
 
 Serves the showoff presentation in the current directory
 
-==== options for serve
-These options are specified *after* the command.
+Options are specified *after* the command.
 
 [<tt>-f, --pres_file=arg</tt>] Presentation file <i>(default: <tt>showoff.json</tt>)</i>
 [<tt>-h, --host=arg</tt>] Host or ip to run on <i>( default: <tt>localhost</tt>)</i>
@@ -171,13 +242,14 @@ These options are specified *after* the command.
 
 Generate static version of presentation
 
-= PDF Output
+= Printable Output
 
-To generate a PDF via your browser rendering engine of choice, simply browse to the <tt>/onepage</tt> view
-and print the page using your browser's native print function.
+To generate printable output or a PDF via your browser rendering engine of choice, simply browse to
+the <tt>/onepage</tt> view and print the page using your browser's native print function. You may
+also use a rendering engine such as PrinceXML[http://www.princexml.com] to print this page to a PDF.
 
-If your browser doesn't generate acceptable output, Showoff can produce a PDF version using the <tt>wkhtmltopdf</tt>
-rendering engine.
+If your browser doesn't generate acceptable output, Showoff can produce a PDF version using the
+<tt>wkhtmltopdf</tt> rendering engine.
 
 To do this, you must install a few things first:
 
@@ -188,7 +260,7 @@ You'll then need to install a version of <tt>wkhtmltopdf</tt> available at the {
     export $PATH="/location/to/my/wkhtmltopdf/0.9.9:$PATH"
 
 
-Then restart showoff, and navigate to <tt>/pdf</tt> (e.g. http://localhost/pdf) of your presentation and a PDF will be generated with the browser.
+Then restart showoff, and navigate to <tt>/pdf</tt> (e.g. http://localhost:9090/pdf) of your presentation and a PDF will be generated with the browser.
 
 = Shell Auto Completion
 


### PR DESCRIPTION
Still left to write is documenting the complete structure of the
`showoff.json` presentation configuration file.
