### PR TITLE
Ported to websockets

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -202,4 +202,3 @@ if GLI::VERSION.to_f > 1
 else
   exit GLI.run(ARGV)
 end
-

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -42,7 +42,7 @@ div.zoomed {
     border-radius: 0.5em;
   }
   #links a:hover {
-    background-color: #555; 
+    background-color: #555;
   }
 
   #topbar #links .mobile {
@@ -89,7 +89,7 @@ div.zoomed {
       display: block;
       color: #000;
       margin: 1px;
-      padding: 0.25em;     
+      padding: 0.25em;
       -moz-border-radius: 0.25em;
       -webkit-border-radius: 0.25em;
       -khtml-border-radius: 0.25em;
@@ -224,7 +224,6 @@ a.controls {
     overflow: hidden;
   }
   #topbar #links .desktop,
-  #statusbar #enableRemote,
   #zoomer,
   #separator,
   #stylepicker {
@@ -247,11 +246,13 @@ a.controls {
   #statusbar * {
     vertical-align: top;
   }
+  #statusbar #enableRemote,
   #statusbar #enableFollower {
     border: none;
     margin: 0;
     padding: 0;
   }
+  #statusbar #remoteToggle,
   #statusbar #followerToggle {
     line-height: 1em;
     height: 1em;

--- a/views/header.erb
+++ b/views/header.erb
@@ -1,7 +1,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title><%= @title %></title>
 
-  <meta name="viewport" content="width=device-width; initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
 
   <link rel="stylesheet" href="<%= @asset_path %>/css/reset.css" type="text/css"/>
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -69,7 +69,7 @@
       </span>
       <div id="debugInfo"></div>
       <input id="zoomer" type="range" min="0.5" max="1.5" step="0.01" onchange="javascript:zoom();" title="Alter the zoom level of the slide preview." />
-      <span id="enableRemote" title="Enables tracking of other presenters after 30 seconds of inactivity. This will glow when listening for remote updates.">
+      <span id="enableRemote" title="Enables tracking of other presenters.">
         <label for="remoteToggle">Enable Remote</label><input type="checkbox" id="remoteToggle" checked />
       </span>
       <span id="enableFollower" title="Send slide change notifications.">


### PR DESCRIPTION
This now uses websockets instead of polling for communications between
all instances. This means that there should be no more funky business
between the presenter window and the remote. Simply advance a slide and
watch every following client track right along. It's like magic!

This should also drastically reduce the load, perhaps making it useful
for large scale presentations. We'll have to see on that one.

The lightweight messaging bus this implements can be used to send
messages of other types. We'll see what sort of interactivity features
we can get nailed in here.

Closes #48 
Closes #87 
