### PR TITLE
Track more useful info about slide viewing

### DIFF
--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.9.6'
+SHOWOFF_VERSION = '0.9.6.1'

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -224,8 +224,18 @@ img#disconnected {
     overflow: auto;
     height: 100%;
   }
+  #notes p,
+  #notes h1,
+  #notes h2,
+  #notes h3,
+  #notes h4,
+  #notes ol,
+  #notes ul {
+    margin-right: 0.75em;
+  }
   #notes p {
     padding: 0.1em inherit;
+    margin-bottom: 0.5em;
   }
   #notes ol, #notes ul {
     padding-left: 2em;

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -226,7 +226,8 @@ reconnectControlChannel = function() {
 
 function update() {
   if(mode.update) {
-    ws.send(JSON.stringify({ message: 'update', slide: slidenum}));
+    var slideName = $("#slideFile").text();
+    ws.send(JSON.stringify({ message: 'update', slide: slidenum, name: slideName}));
   }
 }
 


### PR DESCRIPTION
- Keep track of individual slide views instead of a cumulative time per slide.
- Save a timestamp for each view so we can collate them into a path through the material.
- Save the slide that the presenter is on so we have an idea of where in the presentation other slides are useful.
- Don't truncate stats, merge old & new. This allows multiple Showoff sessions to be collected into one stats file.
