### PR TITLE
Adds printonly & noprint page styles

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -78,6 +78,8 @@ Some useful styles for each slide are:
 [small] make all slide text 80%
 [smaller] make all slide text 70%
 [execute] on Javascript, Coffeescript and Ruby highlighted code slides, you can click on the code to execute it and display the results on the slide
+[printonly] this slide should only appear in the printed version of the presentation
+[noprint] this slide will not appear in the printed version of the presentation
 [supplemental] rather than adding a slide to the main presentation, add a slide to supplemental materials. See below.
 
 Check out the example directory included to see examples of most of these.

--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -42,10 +42,14 @@ web browser. The following URL paths are available for use by you and your audie
   tries to be intelligent about which slide change updates to track.
 
 [http://localhost:9090/onepage]
-  This will generate a single page representing your entire presentation. It is useful
-  for printing, especially, but can also be used when a viewer has an older browser
-  than cannot handle the transitions properly or is a luddite ;-) and wants to scroll
-  rather than page.
+  This will generate a single page representing your entire presentation. It is primarily
+  useful when a viewer has an older browser than cannot handle the transitions properly
+  or is a luddite ;-) and wants to scroll rather than page.
+
+[http://localhost:9090/onepage]
+  This will generate printable version of your presentation, including any slides that
+  were tagged as _printonly_. This view can be printed directly from the browser, or
+  processed with any HTML-to-$thing engine.
 
 [http://localhost:9090/download]
   Your slides can include files for viewers to download and these files will be listed

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -168,8 +168,7 @@ class ShowOff < Sinatra::Application
       end
     end
 
-
-    def process_markdown(name, content, opts={:static=>false, :pdf=>false, :toc=>false, :supplemental=>nil})
+    def process_markdown(name, content, opts={:static=>false, :pdf=>false, :print=>false, :toc=>false, :supplemental=>nil})
       # if there are no !SLIDE markers, then make every H1 define a new slide
       unless content =~ /^\<?!SLIDE/m
         content = content.gsub(/^# /m, "<!SLIDE>\n# ")
@@ -215,6 +214,14 @@ class ShowOff < Sinatra::Application
         unless opts[:toc]
           # just drop the slide if we're not generating a table of contents
           next if slide.classes.include? 'toc'
+        end
+
+        if opts[:print]
+          # drop all slides not intended for the print version
+          next if slide.classes.include? 'noprint'
+        else
+          # drop slides that are intended for the print version only
+          next if slide.classes.include? 'printonly'
         end
 
         @slide_count += 1
@@ -630,6 +637,11 @@ class ShowOff < Sinatra::Application
     def onepage(static=false)
       @slides = get_slides_html(:static=>static, :toc=>true)
       #@languages = @slides.scan(/<pre class=".*(?!sh_sourceCode)(sh_[\w-]+).*"/).uniq.map{ |w| "/sh_lang/#{w[0]}.min.js"}
+      erb :onepage
+    end
+
+    def print(static=false)
+      @slides = get_slides_html(:static=>static, :toc=>true, :print=>true)
       erb :onepage
     end
 


### PR DESCRIPTION
These styles allow you to conditionally include slides in the printed or
electronic versions of the presentation. To get this functionality, you
will need to use the new `/print` endpoint for printable material
instead of `/onepage`.

Closes #106 
