### PR TITLE
Use g and h to go back and forth in slides

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -612,11 +612,11 @@ function keyDown(event)
 		debugMode = !debugMode
 		doDebugStuff()
 	}
-	else if (key == 37 || key == 33 || key == 38) // Left arrow, page up, or up arrow
+	else if (key == 37 || key == 33 || key == 38 || key == 71) // Left arrow, page up, up arrow, or g
 	{
 		prevStep()
 	}
-	else if (key == 39 || key == 34 || key == 40) // Right arrow, page down, or down arrow
+	else if (key == 39 || key == 34 || key == 40 || key == 72) // Right arrow, page down, down arrow, or h
 	{
 		nextStep()
 	}


### PR DESCRIPTION
I'm using [RemoteDroid](http://remotedroid.net/) to use my phone as a remote (the advantage being that the server works on any platform, including Linux) over wifi.

However, RemoteDroid does not have arrow keys, but you can access a virtual keyboard, which lets you use letter keys, so I'm mapping `g` and `h` to prev and next.

This might be useful to other people using this kind of remote control apps.
