### PR TITLE
Fix regular expression for regex

### DIFF
--- a/public/js/sh_lang/sh_puppet.js
+++ b/public/js/sh_lang/sh_puppet.js
@@ -34,7 +34,7 @@ sh_languages['puppet'] = [
       3
     ],
     [
-      /\/[^\n]*\//g,
+      /\/[^\n]*\/\s/g,  // anchor to \s to avoid matching directory names.
       'sh_regexp',
       -1
     ],


### PR DESCRIPTION
Fix regular expression for matching regular expressions to avoid matching directory names, e.g. Fundamentals Language_Constructs/quoting
