### PR TITLE
Ticket/119/change popup behaviour

### DIFF
--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.9.7'
+SHOWOFF_VERSION = '0.9.7.1'

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -45,6 +45,10 @@ div.zoomed {
     background-color: #555;
   }
 
+  #topbar #links a.enabled {
+    background-color: #003d96;
+  }
+
   #topbar #links .mobile {
     display: none;
   }

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -38,7 +38,7 @@
         <% end %>
         <a id="stats" href="/stats" target="_showoffchild">Viewing Statistics</a>
         <a id="downloads" href="/download" target="_showoffchild">Downloads</a>
-        <a id="slaveWindow" href="javascript:openSlave();" title="Open a slave window if your popup blocker prevented it.">Open Slave Window</a>
+        <a id="slaveWindow" href="javascript:toggleSlave();" title="Enable the slave window.">Enable Slave Window</a>
         <a id="generatePDF" href="/pdf" title="Call out to wkhtmltopdf to generate a PDF.">Generate PDF</a>
         <a id="onePage" href="/onepage" title="Load the single page view. Useful for printing.">Single Page</a>
       </span>


### PR DESCRIPTION
The slave window no longer opens by default. It requires an explicit
click on the `Enable Slave Window` button, which will then pop up the
slave. When you disable it, that window/tab will be closed for you.

This is necessitated by Chrome's habit of disallowing configuration of
popup windows that are not initiated by user action. Sorry.

I hope that it also helps with the referenced bug, though I cannot tell
as I cannot reproduce it for testing.

Possibly addresses #119
