### PR TITLE
Issues/125/code review

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -99,6 +99,9 @@ command :serve do |c|
   c.desc 'Show verbose messaging'
   c.switch :verbose
 
+  c.desc 'Enable code review'
+  c.switch :review
+
   c.desc 'Port on which to run'
   c.default_value "9090"
   c.flag [:p,:port]
@@ -138,6 +141,7 @@ To run it from presenter view, go to: [ #{url}/presenter ]
                   :pres_file => options[:f],
                   :pres_dir  => args[0],
                   :verbose   => options[:verbose],
+                  :review    => options[:review],
                   :bind      => options[:h]
   end
 end

--- a/documentation/INTERACTION.rdoc
+++ b/documentation/INTERACTION.rdoc
@@ -49,6 +49,16 @@ To enable this functionality, please set the key <tt>"feedback": true</tt> in yo
   explaining what could be made better on any given slide. The feedback and the current
   slide name are recorded on the presenter's machine for later analysis.
 
+==== Code Review
+
+[Edit Current Slide]
+  If the <tt>showoff.json</tt> file contains an <tt>edit</tt> key and showoff is called
+  with the <tt>--review</tt> command line flag then this button will appear, allowing
+  audience members with sufficient privileges to edit the source of the current slide
+  using an online editor at the configured location. This is most useful when your
+  slide source is stored in GitHub, or another repository that allows interactive editing.
+  This functionality is intended for periodic materials review sessions.
+
 == Presenter Functionality
 
 The presentation control panel provides many tools for interacting with your audience.

--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -82,6 +82,13 @@ tools that you should be familiar with.
   used to generate the slide, so is exponentially more useful than a slide number when
   correlating slide content with the source file used to generate it.
 
+[Edit Slide]
+  If the <tt>showoff.json</tt> file contains an <tt>edit</tt> key then this button
+  will allow presenters to edit the source of the current slide using an online editor
+  at the configured location. This is most useful when your slide source is stored in
+  GitHub, or another repository that allows interactive editing. This button only appears
+  when showoff is called with the <tt>--review</tt> command line flag.
+
 [Report Issue With Slide]
   If the <tt>showoff.json</tt> file contains an <tt>issues</tt> key then this button
   will allow presenters to report problems with the slide currently being viewed

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -45,6 +45,8 @@ class ShowOff < Sinatra::Application
   set :presenters, []
 
   set :verbose, false
+  set :review, false
+
   set :pres_dir, '.'
   set :pres_file, 'showoff.json'
   set :page_size, "Letter"
@@ -70,6 +72,8 @@ class ShowOff < Sinatra::Application
     @logger = Logger.new(STDOUT)
     @logger.formatter = proc { |severity,datetime,progname,msg| "#{progname} #{msg}\n" }
     @logger.level = settings.verbose ? Logger::DEBUG : Logger::WARN
+
+    @review = settings.review
 
     dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
     @logger.debug(dir)
@@ -592,15 +596,21 @@ class ShowOff < Sinatra::Application
         @asset_path = "./"
       end
 
-      @favicon = settings.showoff_config['favicon']
+      # Display favicon in the window if configured
+      @favicon  = settings.showoff_config['favicon']
 
       # Check to see if the presentation has enabled feedback
       @feedback = settings.showoff_config['feedback']
+
+      # Provide a button in the sidebar for interactive editing if configured
+      @edit     = settings.showoff_config['edit'] if @review
+
       erb :index
     end
 
     def presenter
       @issues    = settings.showoff_config['issues']
+      @edit      = settings.showoff_config['edit'] if @review
       @@cookie ||= guid()
       response.set_cookie('presenter', @@cookie)
       erb :presenter

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -300,6 +300,17 @@ img#disconnected {
   text-align: center;
 }
 
+#feedbackSidebar div.row.tools {
+  position: absolute;
+  bottom: 30px;
+  width: 100%;
+  text-align: center;
+}
+
+#feedbackSidebar div.row.tools button#editSlide {
+  width: 90%%;
+  margin: auto 5%;
+}
 
 .fg-menu-container {
     z-index: 2147483647; /* max, see http://www.puidokas.com/max-z-index/ */
@@ -486,10 +497,6 @@ ul#downloads {
 }
 ul#downloads li {
     margin: 0.5em;
-}
-
-span#issueUrl {
-  display: none;
 }
 
 /**********************

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -104,9 +104,14 @@ function popupLoader(elem, page, id, event)
 }
 
 function reportIssue() {
-  var slide  = $("span#slideFile").text();
-  var issues = $("span#issueUrl").text();
-  var link = issues + encodeURIComponent('Issue with slide: ' + slide);
+  var slide = $("span#slideFile").text();
+  var link  = issueUrl + encodeURIComponent('Issue with slide: ' + slide);
+  window.open(link);
+}
+
+function editSlide() {
+  var slide = $("span#slideFile").text();
+  var link  = editUrl + slide + ".md";
   window.open(link);
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -83,6 +83,7 @@ function setupPreso(load_slides, prefix) {
   $("#sendFeedback").click(function() {
     sendFeedback($( "input:radio[name=rating]:checked" ).val(), $("textarea#feedback").val())
   });
+  $("#editSlide").click(function() { editSlide(); });
 
   $("textarea#question").val(questionPrompt);
   $("textarea#feedback").val(feedbackPrompt);
@@ -462,6 +463,13 @@ function track() {
       ws.send(JSON.stringify({ message: 'track', slide: slideName, time: elapsedTime}));
     }
   }
+}
+
+// Open a new tab with an online code editor, if so configured
+function editSlide() {
+  var slide = $("span#slideFilename").text();
+  var link  = editUrl + slide + ".md";
+  window.open(link);
 }
 
 function follow(slide) {

--- a/views/header.erb
+++ b/views/header.erb
@@ -48,7 +48,9 @@
   <% end %>
 
   <script type="text/javascript">
-  $(function(){
+    $(function(){
       setupPreso(<%= @slides.nil? ? "true" : "false"%>, '<%= @asset_path %>');
-  });
+    });
+
+    editUrl  = "<%= @edit %>";
   </script>

--- a/views/index.erb
+++ b/views/index.erb
@@ -41,6 +41,11 @@
           <textarea id="feedback"></textarea>
           <button id="sendFeedback">Send Feedback</button>
         </div>
+        <% if @edit then %>
+        <div class="row tools">
+          <button id="editSlide">Edit Current Slide</button>
+        </div>
+        <% end %>
         <div id="disclaimer">All features are anonymous</div>
     </div>
     <div id="feedbackHandle"></div>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -6,11 +6,13 @@
   <%= erb :header %>
   <link rel="stylesheet" href="<%= @asset_path %>/css/presenter.css" type="text/css"/>
   <script type="text/javascript" src="<%= @asset_path %>/js/presenter.js"></script>
+  <script type="text/javascript">
+    editUrl  = "<%= @edit %>";
+    issueUrl = "<%= @issues %>";
+  </script>
 </head>
 
 <body>
-
-<span id="issueUrl"><%= @issues %></span>
 
 <div id="help">
   <table>
@@ -33,6 +35,9 @@
     </div>
     <span id="links">
       <span class="desktop">
+        <% if @edit %>
+          <a id="edit" href="javascript:editSlide();" title="Edit current slide in new window.">Edit Slide</a>
+        <% end %>
         <% if @issues %>
           <a id="report" href="javascript:reportIssue();" title="Report an issue with the current slide.">Report Issue With Slide</a>
         <% end %>


### PR DESCRIPTION
If `showoff.json` is configured with an `edit` key pointing to the
repository path, and showoff is executed with the `--review` command
line flag, then a button will be displayed in both the Presenter view
and in the sidebar of the Presentation window allowing team members with
access permissions to directly edit slides using the GitHub source
editor.

Note that if the user has commit privileges, changes will be committed
automatically, and if not, they will be submitted as pull requests.

My intent is to create a `qa/review` branch for these edits to take
place on, so we have a single merge commit to point to in the history.

Fixes #125
