### PR TITLE
Reinstate SCRIPT_NAME support.

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -970,8 +970,7 @@ class ShowOff < Sinatra::Application
       protected! if settings.showoff_config['protected'].include? what
     end
 
-    # this hasn't been set to anything remotely interesting for a long time now
-    @asset_path = nil
+    @asset_path = (env['SCRIPT_NAME'] || '').gsub(/^\/?/, '/').gsub(/\/?$/, '')
 
     begin
       if (what != "favicon.ico")


### PR DESCRIPTION
This was removed in d26b427f, breaking the ability to host multiple Showoff decks on the same hostname.
