### PR TITLE
eliminate the presenter jump on next view open

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -600,7 +600,7 @@ class ShowOff < Sinatra::Application
       @favicon  = settings.showoff_config['favicon']
 
       # Check to see if the presentation has enabled feedback
-      @feedback = settings.showoff_config['feedback']
+      @feedback = settings.showoff_config['feedback'] unless params[:feedback] == 'false'
 
       # Provide a button in the sidebar for interactive editing if configured
       @edit     = settings.showoff_config['edit'] if @review

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -38,6 +38,7 @@
       border-top-left-radius: 3px;
       border-top-right-radius: 3px;
       z-index: 2147483647; /* max, see http://www.puidokas.com/max-z-index/ */
+      display: none;
   }
   #followMode {
     display: none;

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -163,7 +163,7 @@ function nextSlideNum(url) {
   console.log(typeof(url));
   var snum;
   if (typeof(url) == 'undefined') { snum = currentSlideFromParams()+1; }
-  else { snum = currentSlideFromParams()+2; } 
+  else { snum = currentSlideFromParams()+2; }
   return snum;
 }
 
@@ -177,11 +177,11 @@ function openNext()
   if (mode.next) {
     try {
       if(nextWindow == null || typeof(nextWindow) == 'undefined' || nextWindow.closed){
-          nextWindow = window.open('/?track=false#' + nextSlideNum(true),'','width=300,height=200');
+          nextWindow = window.open('/?track=false&feedback=false&next=true#' + nextSlideNum(true),'','width=300,height=200');
       }
       else if(nextWindow.location.hash != '#' + nextSlideNum(true)) {
         // maybe we need to reset content?
-        nextWindow.location.href = '/?track=false#' + nextSlideNum(true);
+        nextWindow.location.href = '/?track=false&feedback=false&next=true#' + nextSlideNum(true);
       }
 
       // maintain the pointer back to the parent.
@@ -326,7 +326,7 @@ function presPrevStep()
   try { slaveWindow.prevStep(false) } catch (e) {};
   try { nextWindow.gotoSlide(nextSlideNum()) } catch (e) {};
   postSlide();
-  
+
   update();
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -60,6 +60,9 @@ function setupPreso(load_slides, prefix) {
   // give us the ability to disable tracking via url parameter
   if(query.track == 'false') mode.track = false;
 
+  // make sure that the next view doesn't bugger things on the first load
+  if(query.next == 'true')   mode.next = true;
+
   // Make sure the slides always look right.
   // Better would be dynamic calculations, but this is enough for now.
   $(window).resize(function(){location.reload();});
@@ -91,7 +94,9 @@ function setupPreso(load_slides, prefix) {
   $("textarea#feedback").focus(function() { clearIf($(this), feedbackPrompt) });
 
   // Open up our control socket
-  connectControlChannel();
+  if(mode.track) {
+    connectControlChannel();
+  }
 /*
   ws           = new WebSocket('ws://' + location.host + '/control');
   ws.onopen    = function()  { connected();          };
@@ -300,7 +305,7 @@ function showSlide(back_step, updatepv) {
   $('#slideFilename').text(fileName);
 
   // Update presenter view, if we spawned one
-	if (updatepv && 'presenterView' in window) {
+	if (updatepv && 'presenterView' in window && ! mode.next) {
     var pv = window.presenterView;
 		pv.slidenum = slidenum;
     pv.incrCurr = incrCurr


### PR DESCRIPTION
This cleans up the next view a bit
- removes the feedback widget
- hides the footer on load (for all views)
- stops the next view from updating the presenter
