### PR TITLE
default to first slide instead of last.

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -203,13 +203,15 @@ function checkSlideParameter() {
 
 function currentSlideFromName(name) {
   var count = 0;
-	slides.each(function(s, slide) {
-	  if (name == $(slide).find(".content").attr("ref") ) {
-	    found = count;
-	    return false;
-	  }
-	  count++;
-	});
+  if(name.length > 0 ) {
+  	slides.each(function(s, slide) {
+  	  if (name == $(slide).find(".content").attr("ref") ) {
+  	    found = count;
+  	    return false;
+  	  }
+  	  count++;
+  	});
+	}
 	return count;
 }
 


### PR DESCRIPTION
The named anchors patch I merged had a flaw in how it merged slide
numbers and names.
