### PR TITLE
assign the feedback settings only if params is not nil

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -596,9 +596,9 @@ class ShowOff < Sinatra::Application
 
       # Display favicon in the window if configured
       @favicon  = settings.showoff_config['favicon']
-
+      
       # Check to see if the presentation has enabled feedback
-      @feedback = settings.showoff_config['feedback'] unless params[:feedback] == 'false'
+      @feedback = settings.showoff_config['feedback'] unless params[:feedback] == 'false' if params
 
       # Provide a button in the sidebar for interactive editing if configured
       @edit     = settings.showoff_config['edit'] if @review

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -596,7 +596,7 @@ class ShowOff < Sinatra::Application
 
       # Display favicon in the window if configured
       @favicon  = settings.showoff_config['favicon']
-      
+
       # Check to see if the presentation has enabled feedback
       @feedback = settings.showoff_config['feedback'] unless params[:feedback] == 'false' if params
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -598,7 +598,7 @@ class ShowOff < Sinatra::Application
       @favicon  = settings.showoff_config['favicon']
 
       # Check to see if the presentation has enabled feedback
-      @feedback = settings.showoff_config['feedback'] unless params[:feedback] == 'false' if params
+      @feedback = settings.showoff_config['feedback'] if (params && params[:feedback] == 'true')
 
       # Provide a button in the sidebar for interactive editing if configured
       @edit     = settings.showoff_config['edit'] if @review


### PR DESCRIPTION
``` bash
$ showoff static
error: undefined method '[]' for nil:NilClass
```

It seems the `params` variable is nil in this case.
