### PR TITLE
Typo fixes

### DIFF
--- a/CONTRIB.txt
+++ b/CONTRIB.txt
@@ -1,9 +1,9 @@
 Contributing
 ======================
 
-To contribute to the ShowOff project:
+To contribute to the Showoff project:
 
-* Fork schacon/showoff
+* Fork puppetlabs/showoff
 
 * Use the ShowOff project in the 'example/' subdirectory to 
   add an example of new features or make sure you haven't

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
-= ShowOff Presentation Software
+= Showoff Presentation Software
 
-ShowOff is a Sinatra web app that reads simple configuration files for a
+Showoff is a Sinatra web app that reads simple configuration files for a
 presentation.  It is sort of like a Keynote web app engine - think S5 +
 Slidedown.  I am using it to do all my talks in 2010, because I have a deep
 hatred in my heart for Keynote and yet it is by far the best in the field.
@@ -50,7 +50,7 @@ Please see the documentation in <tt>./documentation</tt> for further information
 
 = Real World Usage
 
-So far, ShowOff has been used in the following presentations (and many others):
+So far, Showoff has been used in the following presentations (and many others):
 
 * LinuxConf.au 2010 - Wrangling Git - Scott Chacon
   http://github.com/schacon/showoff-wrangling-git

--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -1,6 +1,6 @@
 = Usage
 
-ShowOff is meant to be run in a ShowOff formatted repository - that means that
+Showoff is meant to be run in a Showoff formatted repository - that means that
 it has a <tt>showoff.json</tt> file and a number of sections (subdirectories) with
 markdown files for the slides you're presenting.
 
@@ -8,7 +8,7 @@ markdown files for the slides you're presenting.
     $ cd (showoff-repo)
     $ showoff serve
 
-If you run Showoff in the example subdirectory of ShowOff itself, it will
+If you run Showoff in the example subdirectory of Showoff itself, it will
 show an example presentation, so you can see what it's like.
 
 You can also run <tt>showoff serve</tt> inside a section subdirectory. If there is no
@@ -46,7 +46,7 @@ web browser. The following URL paths are available for use by you and your audie
   useful when a viewer has an older browser than cannot handle the transitions properly
   or is a luddite ;-) and wants to scroll rather than page.
 
-[http://localhost:9090/onepage]
+[http://localhost:9090/print]
   This will generate printable version of your presentation, including any slides that
   were tagged as _printonly_. This view can be printed directly from the browser, or
   processed with any HTML-to-$thing engine.


### PR DESCRIPTION
Changed instances of ShowOff to Showoff. Changed print view instruction to be correct localhost:9090/print rather than incorrect localhost:9090/one-page.
