### PR TITLE
Form support in the slides

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -85,6 +85,7 @@ Some useful styles for each slide are:
 [printonly] this slide should only appear in the printed version of the presentation
 [noprint] this slide will not appear in the printed version of the presentation
 [supplemental] rather than adding a slide to the main presentation, add a slide to supplemental materials. See below.
+[form=id] Render form elements on this slide with a given form ID. See below, and in FORMS.rdoc.
 
 Check out the example directory included to see examples of most of these.
 
@@ -206,6 +207,11 @@ Supported languages include:
 
 Instructions for adding support for new languages can be found at http://shjs.sourceforge.net/doc/documentation.html
 
+= Forms
+
+Showoff extends Markdown to render a limited subset of form elements. This is mostly useful for polls,
+quizzes, surveys, etc. See FORMS.rdoc for more complete information.
+
 = Sections
 
 == Presenter Notes
@@ -257,6 +263,10 @@ contain any markup that the slide itself can.
 [~~~TOC~~~]
   Generates a Table of Contents using the subsection titles. Some renderers (such as
   PrinceXML[http://www.princexml.com]) are able to autonumber the table with links to content.
+
+[~~~FORM:id~~~]
+  Places a continuously updating block displaying the live results from the form with the given ID.
+  This is most useful when you're performing a poll or pop quiz during the presentation.
 
 = Preshow
 

--- a/documentation/FORMS.rdoc
+++ b/documentation/FORMS.rdoc
@@ -1,0 +1,117 @@
+= Form support
+
+Showoff extends Markdown to render a limited subset of form elements. This is
+mostly useful for polls, quizzes, surveys, etc. These extensions are only
+rendered on slide that have been marked as forms.
+
+Form responses are saved to a JSON file on disk, <tt>stats/forms.json</tt>, and
+cached in memory for quick access. Responses are keyed by form ID and IP
+address. Each IP has only one response saved, and subsequent submissions will
+overwrite.  Showoff saves and reloads data from disk, so you can run the
+presentation multiple times without data loss. Just like
+<tt>stats/viewstats.json</tt>, you should remove the file prior to starting the
+presentation if you'd like to start from a clean slate.
+
+Responses can optionally be displayed live in the presenter view.
+
+== Marking a slide
+
+Each slide containing a form must be marked as such by including that form's ID
+in the slide signature.  For example, to create a slide that posts to the id of
+`experience`, the slide signature that you might use could look like:
+
+    <!SLIDE form=experience>
+
+== Markdown extensions
+
+Form slides are rendered via Markdown extension with the general form of:
+
+    question = answer(s)
+
+Both sides, the question and the answer(s) are tokenized so that they may be
+represented as either a single continuous string, or a key and a string. This
+would look like:
+
+    key -> A human readable representation of the element
+
+If the `=` sign has an asterisk prepended, then the field is marked as required.
+
+    question *= answer(s)
+
+=== Form element syntax
+
+The right hand side (answer) can be rendered in the following ways:
+
+[text field]
+  Three or more consecutive underscores, followed by an optional length.
+
+    name = ___
+
+    name = ___[50]
+
+    name -> What is your name? = ___[50]
+
+[text area]
+  Whitespace surrounded by square brackets, including an optional number of rows.
+
+    comments = [   ]
+
+    comments = [   5]
+
+[radio buttons]
+  Delineate a list of options on the right hand side with parentheses, optionally
+  marking one as default using an `x`. This accepts the tokenized form for a key
+  and a full human readable string. If options are placed on multiple lines
+  indented by 3+ spaces, then the output will be rendered as a bullet list.
+
+    smartphone = () iPhone () Android () other -> Any other phone not listed
+
+    awake -> Are you paying attention? = (x) No () Yes
+
+    continent =
+        () Africa
+        () Americas
+        () Asia
+        () Australia
+        () Europe
+
+[checkboxes]
+  Works exactly like radio boxes, only using square brackets as delineators.
+
+    smartphone = [] iPhone [] Android [x] other -> Any other phone not listed
+
+[combo select]
+  Surround options on the right hand side with curly brackets and a combo select
+  box will be rendered. If you place the options on multiple lines, you can use
+  the long tokenized form. The shorthand single line syntax supports keys only.
+  The default option may be specified by surrounding an option with parentheses.
+
+    smartphone = {iPhone, Android, Other }
+
+    smartphone = {iPhone, Android, (Other) }
+
+    smartphone = {iPhone, Android, (other -> Any other phone not listed) }
+
+    cuisine -> What is your favorite cuisine? = { American, Italian, French }
+
+    cuisine -> What is your favorite cuisine? = {
+          US -> American,
+          IT -> Italian,
+          FR -> French
+        }
+
+== Viewing results
+
+A continuously updating block displaying the live results from a given form ID
+can be embedded into the presenter notes using the syntax below. The ID should
+match the ID of a form created by marking a slide with a form tag.
+
+    ~~~FORM:id~~~
+
+This will display all data that can be rendered in aggregate form as a horizontal
+bar chart that updates every three seconds. Free entry elements are not displayed.
+
+The presenter view also includes a <em>Display Results</em> button instead of the
+<em>Save</em> button that audience members see. Pressing this button will render
+a single snapshot of the current results over the slave window. This will commonly
+be displayed on the projector. Pressing the button again will update the results.

--- a/documentation/FORMS.rdoc
+++ b/documentation/FORMS.rdoc
@@ -95,8 +95,8 @@ The right hand side (answer) can be rendered in the following ways:
     cuisine -> What is your favorite cuisine? = { American, Italian, French }
 
     cuisine -> What is your favorite cuisine? = {
-          US -> American,
-          IT -> Italian,
+          US -> American
+          IT -> Italian
           FR -> French
         }
 
@@ -115,3 +115,40 @@ The presenter view also includes a <em>Display Results</em> button instead of th
 <em>Save</em> button that audience members see. Pressing this button will render
 a single snapshot of the current results over the slave window. This will commonly
 be displayed on the projector. Pressing the button again will update the results.
+
+== Example slide
+
+    <!SLIDE form=classinfo>
+    # Making Acquaintances
+    ## Let's get to know each other
+
+    Tell me a little bit about yourself to help me better tailor the classroom
+    experience towards your needs.
+
+    howlong -> How long have have you been using Puppet? = {
+       under -> Less than six months
+       6mo -> Around six months
+       1yr -> About a year
+       2yr -> Two years or so
+       more -> Since before Puppet Enterprise was a sparkle in Luke's eye, get offa my lawn.
+    }
+
+    job -> What is your work role? =
+        [] support -> Technical Support
+        [] Sysadmin
+        [] dbadmin -> DB Admin
+        [] Developer
+        [] Management
+
+
+    usedpe -> Have you used Puppet Enterprise? = () Yes () No
+
+    prepared -> Do you feel prepared for this class? = () Yes () No
+
+    ~~~SECTION:notes~~~
+
+    Tell the class a little bit about yourself and your own background.
+
+    ~~~FORM:classinfo~~~
+
+    ~~~ENDSECTION~~~

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -428,7 +428,7 @@ class ShowOff < Sinatra::Application
     def form_element(id, name, required, rhs, text)
       required = required ? 'required' : ''
       str =  "<div class='form element #{required}' id='#{id}'>"
-      str << "<label for='#{id}'>#{name}:</label>"
+      str << "<label for='#{id}'>#{name}</label>"
       case rhs
       when /^\[\s+(\d*)\]$$/             # value = [    5]                                    (textarea)
         str << form_element_textarea(id, name, $1)

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -157,6 +157,13 @@ div.zoomed {
     background: #eee;
   }
 
+#preview .content form div.tools input[type=button].display {
+  display: inline;
+}
+#preview .content form div.tools input[type=submit] {
+  display: none;
+}
+
 img#disconnected {
   margin: 0.5em 1em;
 }

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -522,6 +522,9 @@ div.rendered.form .item.barstyle2 { background-color: #e3742f; }
 div.rendered.form .item.barstyle3 { background-color: #4848e8; }
 div.rendered.form .item.barstyle4 { background-color: #f75d5d; }
 
+#notes .form.wrapper {
+  display: none;
+}
 
 /**********************************
  ***   supplemental materials   ***

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -478,9 +478,11 @@ a.fg-button { float:left; }
 #preview .content div.form.element select {
   font-size: 0.8em;
 }
+.content div.form.element.warning {
+  background-color: #ff7373;
+}
 .content form div.tools {
   font-size: 2em;
-  border-top: 1px solid black;
 }
 .content form div.tools * {
   float: right;
@@ -490,7 +492,10 @@ a.fg-button { float:left; }
   margin: 1em;
 }
 .content form div.tools input[type=submit].dirty {
-  background: red;
+  color: red;
+}
+.content form div.tools input[type=button].display {
+  display: none;
 }
 
 div.rendered.form {
@@ -502,6 +507,7 @@ div.rendered.form {
 div.rendered.form label {
   display: block;
   font-weight: bold;
+  border-bottom: 1px solid #999;
 }
 div.rendered.form .item {
   display: block;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -454,17 +454,28 @@ a.fg-button { float:left; }
 /**********************************
  ***       form widgets         ***
  **********************************/
-.content form label {
+.content div.form.element {
+    text-align: left;
+    padding-left: 40px;
+}
+.content div.form.element label {
   margin-right: 0.5em;
 }
-.content form select {
+.content div.form.element select {
   font-size: 2em;
 }
-.content form textarea {
+.content div.form.element textarea {
   display: block;
+  width: 85%;
+}
+.content div.form.element ul {
+  list-style: disc;
+}
+.content div.form.element ul > li {
+  margin-left: 40px;
 }
 /* TODO: not sure why the preview window honks things up */
-#preview .content form select {
+#preview .content div.form.element select {
   font-size: 0.8em;
 }
 .content form div.tools {
@@ -495,10 +506,16 @@ div.rendered.form label {
 div.rendered.form .item {
   display: block;
   width: 0;
-  overflow: hidden;
-  text-wrap: none;
-  background-color: red;
+/*   overflow: hidden; */
+  height: 1.25em;
+  white-space: nowrap;
 }
+div.rendered.form .item.barstyle0 { background-color: #bb73bb; }
+div.rendered.form .item.barstyle1 { background-color: #59b859; }
+div.rendered.form .item.barstyle2 { background-color: #e3742f; }
+div.rendered.form .item.barstyle3 { background-color: #4848e8; }
+div.rendered.form .item.barstyle4 { background-color: #f75d5d; }
+
 
 /**********************************
  ***   supplemental materials   ***

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -61,16 +61,19 @@
 }
 
 /* plain (non-bullet) text */
-.content > p {
-	font-size: 2em;
+.content > p,
+.content > form > p {
+    font-size: 2em;
     margin: 1em;
-	text-align: center;
+    text-align: center;
 }
 
-.content > pre {
+.content > pre,
+.content > form > pre {
     font-size: 300%;
 }
-.content > blockquote {
+.content > blockquote,
+.content > form > blockquote {
     font-size: 250%;
     margin: 2em;
 }
@@ -92,9 +95,9 @@
 /* numbered lists are numbered */
 .content ol {
     margin-left: 40px;
-	font-size: 3em;
-	text-align: left;
-	padding-left: 40px;
+    font-size: 3em;
+    text-align: left;
+    padding-left: 40px;
 }
 .content ol > li {
     list-style: decimal;
@@ -103,15 +106,15 @@
 
 
 /* ironically, normal lists have bullets and 'bullets' lists don't */
-.content > ul {
+.content > ul,
+.content > form > ul {
     list-style: disc;
+    font-size: 3em;
+    text-align: left;
+    padding-left: 40px;
 }
-.content > ul {
-	font-size: 3em;
-	text-align: left;
-	padding-left: 40px;
-}
-.content > ul > li {
+.content > ul > li,
+.content > form > ul > li {
     padding: .5em;
     margin-left: 40px;
 }
@@ -446,6 +449,52 @@ a.fg-button { float:left; }
 }
 #toc a::after {
   content: leader(".") target-counter(attr(href), page);
+}
+
+/**********************************
+ ***       form widgets         ***
+ **********************************/
+.content form label {
+  margin-right: 0.5em;
+}
+.content form select {
+  font-size: 2em;
+}
+/* TODO: not sure why the preview window honks things up */
+#preview .content form select {
+  font-size: 0.8em;
+}
+.content form div.tools {
+  font-size: 2em;
+  border-top: 1px solid black;
+}
+.content form div.tools * {
+  float: right;
+}
+.content form div.tools input[type=submit],
+.content form div.tools input[type=button] {
+  margin: 1em;
+}
+.content form div.tools input[type=submit].dirty {
+  background: red;
+}
+
+div.rendered.form {
+  border: 1px solid #ccc;
+  border-radius: 0.5em;
+  margin: 1em;
+  padding: 0.25em;
+}
+div.rendered.form label {
+  display: block;
+  font-weight: bold;
+}
+div.rendered.form .item {
+  display: block;
+  width: 0;
+  overflow: hidden;
+  text-wrap: none;
+  background-color: red;
 }
 
 /**********************************

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -460,6 +460,9 @@ a.fg-button { float:left; }
 .content form select {
   font-size: 2em;
 }
+.content form textarea {
+  display: block;
+}
 /* TODO: not sure why the preview window honks things up */
 #preview .content form select {
   font-size: 0.8em;

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -357,11 +357,20 @@ function postSlide()
 		  var notes = getCurrentNotes()
 		}
 */
-    var notes = getCurrentNotes()
-		$('#notes').html(notes.html())
+    // clear out any existing rendered forms
+    try { clearInterval(renderFormInterval) } catch(e) {}
+    $('#notes div.form').empty();
 
-		var fileName = currentSlide.children().first().attr('ref')
-		$('#slideFile').text(fileName)
+    var notes = getCurrentNotes();
+		$('#notes').html(notes.html());
+
+		var fileName = currentSlide.children().first().attr('ref');
+		$('#slideFile').text(fileName);
+
+    $("#notes div.form").each(function(e) {
+      renderFormInterval = renderFormWatcher($(this));
+    });
+
 	}
 }
 

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -367,7 +367,7 @@ function postSlide()
 		var fileName = currentSlide.children().first().attr('ref');
 		$('#slideFile').text(fileName);
 
-    $("#notes div.form").each(function(e) {
+    $("#notes div.form.wrapper").each(function(e) {
       renderFormInterval = renderFormWatcher($(this));
     });
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -529,6 +529,9 @@ function renderForm(form) {
 
               if(! text.match(/^-+$/)) {
                 parent.append('<div class="item barstyle'+style+'" id="'+value+'">'+text+'</div>');
+
+                // loop style counter
+                style++; style %= max;
               }
             });
             $(this).remove();

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -161,6 +161,16 @@ function initializePresentation(prefix) {
     submitForm($(this));
   });
 
+  // suspend hotkey handling
+  $(".content form :input").focus( function() {
+    document.onkeydown = null;
+    document.onkeyup   = null;
+  });
+  $(".content form :input").blur( function() {
+    document.onkeydown = keyDown;
+    document.onkeyup   = keyUp;
+  });
+
   $(".content form :input").change(function(e) {
     enableForm($(this));
   });
@@ -464,9 +474,11 @@ function renderForm(form) {
       $(this).children(':input').each(function() {
         switch( $(this).attr('type') ) {
           case 'text':
-          case 'submit':
           case 'button':
+          case 'submit':
+          case 'textarea':
             // we don't render these
+            $(this).parent().remove();
             break;
 
           case 'radio':

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -522,6 +522,8 @@ function renderForm(form) {
         if(count) { sum += count; }
       });
 
+      var max   = 5;
+      var style = 0;
       $(this).find('.item').each(function() {
         var name  = $(this).attr('id');
         var count = data[key][name];
@@ -534,8 +536,10 @@ function renderForm(form) {
           console.log(percent);
 
           $(this).attr('data-count', count);
+          $(this).addClass('barstyle'+style);
           $(this).animate({width: percent});
-          //$(this).width(percent);
+
+          style++; style %= max;
         }
       });
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -466,6 +466,8 @@ function renderFormWatcher(element) {
   });
 
   renderForm(element);
+  // short pause to let the form be rebuilt. Prevents screen flashing.
+  setTimeout(function() { element.show(); }, 100);
   return setInterval(function() { renderForm(element); }, 3000);
 }
 


### PR DESCRIPTION
This will allow us to present interactive quizzes after topics to gauge
immediate student comprehension. We can quiz towards the end to gauge
retention as well.

This will also allow us to collect survey data directly, making us
Internet independent.

Features:
- Create HTML forms using custom markdown syntax
  - Can specify machine parsable keys & human readable labels
  - Supports radio/checkbox/select/text/textarea
  - Specify defaults for radio/checkbox/select
  - Radio/checkboxes specified on multiple lines become list items
  - Selects can be specified on multiple lines for readability.
- Keys responses by IP address to eliminate duplication
- Students can resubmit if they change responses
- Markup to provide instructor with live reporting of responses
- Button to display results on projector (static only for now)
- All form responses saved in existing metadata uploaded by classroom
  automation tools.

TODO:
- Documentation.
- Clean up presentation. A lot.
- Form validation for required elements.
- Track down and fix the sneaky crasher that seems to be showing up more
  often now.
- More testing.
