### PR TITLE
Github/152/fix params again

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+0.9.9.1
+  * Fix `showoff static` again.
+
 0.9.9
   * Added HTML form support
   * Fixed paging bug

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -767,7 +767,7 @@ class ShowOff < Sinatra::Application
       @favicon  = settings.showoff_config['favicon']
 
       # Check to see if the presentation has enabled feedback
-      @feedback = settings.showoff_config['feedback'] unless params[:feedback] == 'false'
+      @feedback = settings.showoff_config['feedback'] unless (params && params[:feedback] == 'false')
 
       # Provide a button in the sidebar for interactive editing if configured
       @edit     = settings.showoff_config['edit'] if @review

--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,3 +1,3 @@
 # No namespace here since ShowOff is a class and I'd have to inherit from
 # Sinatra::Application (which we don't want to load here)
-SHOWOFF_VERSION = '0.9.9'
+SHOWOFF_VERSION = '0.9.9.1'


### PR DESCRIPTION
The earlier fix was inadvertently reverted. This fixes it in a cleaner way.
