### PR TITLE
highlight current item and scrol to view

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -138,6 +138,7 @@ div.zoomed {
       border-radius: 0.25em;
       text-decoration: none;
     }
+    .menu li.highlighted a,
     .menu a:hover {
       margin: 0;
       border: 1px solid #ccc;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -285,7 +285,7 @@ function showFirstSlide() {
 function showSlide(back_step, updatepv) {
   // allows the master presenter view to disable the update callback
   updatepv = (typeof(updatepv) === 'undefined') ? true : updatepv;
-  
+
 	if(slidenum < 0) {
 		slidenum = 0
 		return
@@ -347,16 +347,20 @@ function showSlide(back_step, updatepv) {
 		pv.postSlide();
 
 		pv.update();
-		
+
 	}
-	
-    // Update presenter view nav for current slide
-    $( ".menu > ul > li > ul > li" ).each(function() {
-      if ($(this).text().split(". ")[0] == slidenum+1) {
-		$(".menu > ul > li > ul ").hide(); //Collapse nav
-        $(this).parent().show(); //Show nav block containing current slide
-      }});
-	  
+
+  // Update presenter view nav for current slide
+  $( ".menu > ul > li > ul > li" ).each(function() {
+    if ($(this).text().split(". ")[0] == slidenum+1) {
+      $(".menu > ul > li > ul ").hide();  //Collapse nav
+      $(".menu > ul > li > ul > li").removeClass('highlighted');
+      $(this).addClass('highlighted'); //Highlight current menu item
+      $(this).parent().show();         //Show nav block containing current slide
+      $(this).get(0).scrollIntoView(); //Scroll so current item is at the top of the view
+    }
+  });
+
 	return ret;
 }
 


### PR DESCRIPTION
This extends the menu expansion commit to also highlight the current
slide in the menu, and also to scroll the view to ensure that menu
entry is visible.
