### PR TITLE
Enable extensions by default

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -64,7 +64,21 @@ or in the upper left of the presenter view.
 == Markdown Format
 
 Showoff renders Markdown format as documented at http://daringfireball.net/projects/markdown/syntax.
-Extensions to the language are documented below.
+Many of the rendering engines supported by Showoff provide extensions allowing more
+formatting options not available in core Markdown. Each engine provides different options
+and the defaults for each are documented in the Markdown Engine section. The full options
+supported by each engine can be found in their respective documentations.
+
+Some of the extensions include:
+
+[autolink] Recognize and parse bare links even when they are not marked up properly.
+[definition_lists] Parse definition lists, {PHP-Markdown}[https://michelf.ca/projects/php-markdown/extra/#def-list] style.
+[strikethrough] Parse strikethrough text surrounded with two <tt>~~</tt> characters.
+[superscript] Parse superscripts after a `^` character.
+[tables] Parse tables, {PHP-Markdown}[https://michelf.ca/projects/php-markdown/extra/#table] style.
+[underline] Parse underscored emphasis as underlines. This is <tt>\_underlined\_</tt> but this is still <tt>\*emphasis\*</tt>.
+
+Showoff extensions to the language are documented below.
 
 = Slide Styles
 
@@ -566,6 +580,46 @@ For example:
 
 Configuring an engine (or overriding its default configuration) allows you to
 access special features of that engine.
+
+=== Default options
+
+Showoff configures default options for some of the Markdown engines. These
+defaults can be disabled in your <tt>showoff.json</tt> file if needed.
+
+Defaults for each engine are:
+
+[redcarpet]
+
+  https://github.com/vmg/redcarpet
+
+    "redcarpet" : {
+      :autolink"          : true,
+      :no_intra_emphasis" : true,
+      :strikethrough"     : true,
+      :superscript"       : true,
+      :tables"            : true,
+      :underline"         : true
+    }
+
+[bluecloth]
+
+  https://github.com/ged/bluecloth/blob/master/lib/bluecloth.rb
+
+    "bluecloth" : {
+      "auto_links"        : true,
+      "definition_lists"  : true,
+      "strikethrough"     : true,
+      "superscript"       : true,
+      "tables"            : true
+    }
+
+[rdiscount]
+
+  https://github.com/davidfstr/rdiscount/blob/master/lib/rdiscount.rb
+
+    "rdiscount" : {
+      "autolink"          : true
+    }
 
 === Maruku
 

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -323,7 +323,7 @@ class ShowOffUtils
     get_config_option(dir, "markdown", "redcarpet")
   end
 
-  def self.showoff_renderer_options(dir = '.', default_options = {})
+  def self.showoff_renderer_options(dir = '.', default_options = MarkdownConfig::defaults(dir))
     opts = get_config_option(dir, showoff_markdown(dir), default_options)
     Hash[opts.map {|k, v| [k.to_sym, v]}] if opts    # keys must be symbols
   end
@@ -445,6 +445,36 @@ module MarkdownConfig
     else
       Tilt.prefer Tilt::RedcarpetTemplate, "markdown"
 
+    end
+  end
+
+  def self.defaults(dir_name)
+    case ShowOffUtils.showoff_markdown(dir_name)
+    when 'rdiscount'
+      {
+        :autolink          => true,
+      }
+    when 'maruku'
+      {}
+    when 'bluecloth'
+      {
+        :auto_links        => true,
+        :definition_lists  => true,
+        :strikethrough     => true,
+        :superscript       => true,
+        :tables            => true,
+      }
+    when 'kramdown'
+      {}
+    else
+      {
+        :autolink          => true,
+        :no_intra_emphasis => true,
+        :strikethrough     => true,
+        :superscript       => true,
+        :tables            => true,
+        :underline         => true,
+      }
     end
   end
 end

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -234,6 +234,52 @@ img#disconnected {
     font-weight: bold;
 }
 
+/**********************************
+ ***       Table styling        ***
+ **********************************/
+
+.content table {
+    margin-left: auto;
+    margin-right: auto;
+    border-collapse:collapse;
+    width: 80%;
+    font-size: 1.7em;
+}
+
+.content.small table {
+    font-size: 1.6em;
+    width: 90%;
+}
+.content.smaller table {
+    font-size: 1.5em;
+    width: 95%;
+}
+
+.content table th {
+    border-bottom: 2px solid #ccc;
+    padding: 0.5em;
+    font-weight: bold;
+}
+
+.content table tr td {
+    border-right: 1px solid #eee;
+    border-bottom: 1px solid #efefef;
+    text-align: center;
+    padding: 0.5em;
+}
+
+.content table tr td:last-child {
+    border-right: none;
+}
+
+.content table li {
+    list-style-type: disc;
+}
+
+
+/**********************************
+ ***      Sidebar styling       ***
+ **********************************/
 
 #feedbackWrapper {
   float: left;


### PR DESCRIPTION
This enables extensions such as:
- `autolink`: automatically recognize links
- `definition_lists`: PHP-Markdown style definition lists
- `no_intra_emphasis`: mid-word underscores don't screw up formatting
- `strikethrough`: surround words with `~~` to strikethrough
- `superscript`: superscript text using `^`
- `tables`: PHP-Markdown style tables
- `underline`: Use underscores for underline instead of emphasis

Not all of these options are available for each engine, and they can all
be disabled if needed in your `showoff.json` file. The AUTHORING docs
page has more information on the default options for each engine.

Fixes #126 
