### PR TITLE
Output (more) valid html

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -640,7 +640,7 @@ class ShowOff < Sinatra::Application
     end
 
     def update_commandline_code(slide)
-      html = Nokogiri::HTML.parse(slide)
+      html = Nokogiri::HTML::DocumentFragment.parse(slide)
       parser = CommandlineParser.new
 
       html.css('pre').each do |pre|
@@ -682,7 +682,7 @@ class ShowOff < Sinatra::Application
         end
         transform.apply(tree)
       end
-      html.root.to_s
+      html.to_html
     end
 
     def get_slides_html(opts={:static=>false, :pdf=>false, :toc=>false, :supplemental=>nil})

--- a/views/404.erb
+++ b/views/404.erb
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/views/download.erb
+++ b/views/download.erb
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -11,7 +10,7 @@
     <div id="preso">
       <div id="wrapper">
         <h1>File Downloads</h1>
-        
+
         <ul id="downloads">
             <% if @downloads %>
                 <%# [ enabled, slide name, [array, of, files] ] %>
@@ -28,7 +27,7 @@
                     <% end %>
                 <% end %>
             <% end %>
-            
+
         </ul>
       </div>
     </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <%= erb :header_mini %>
-    
+
     <script type="text/javascript">
         $(document).ready(function(){ setupStats(); });
     </script>
@@ -14,7 +13,7 @@
     <div id="preso">
       <div id="wrapper">
         <h1>Viewing Statistics</h1>
-        
+
         <div id="least">
           <h3>Least viewed slides</h3>
           <% if @least.size > 0 %>
@@ -29,7 +28,7 @@
             <% end %>
           <% end %>
         </div>
-        
+
         <div id="most">
           <h3>Most viewed slides</h3>
           <% if @least.size > 0 %>
@@ -44,7 +43,7 @@
             <% end %>
           <% end %>
         </div>
-        
+
         <div id="all">
           <h3>All slides</h3>
           <%# We reuse the max value calculated from the above step. %>
@@ -65,7 +64,7 @@
                 </div>
               <% end %>
             </div>
-          <% end %>  
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This does two things:
- Use a document fragment so Nokogiri doesn't litter the output with hundreds of open&close body tags.
- Drop the old style doctype in favor of html5.

Fixes #189 
