### PR TITLE
Fix notes for current redcarpet

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -460,7 +460,6 @@ module MarkdownConfig
       {
         :auto_links        => true,
         :definition_lists  => true,
-        :strikethrough     => true,
         :superscript       => true,
         :tables            => true,
       }
@@ -470,7 +469,6 @@ module MarkdownConfig
       {
         :autolink          => true,
         :no_intra_emphasis => true,
-        :strikethrough     => true,
         :superscript       => true,
         :tables            => true,
         :underline         => true,


### PR DESCRIPTION
Newer versions of redcarpet break the notes sections with `:strikethrough` enabled.
