### PR TITLE
This adds the capability for personal notes

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -240,6 +240,16 @@ will also  display shorter notes. Toggle these with the n key while in the prese
 
     ~~~ENDSECTION~~~
 
+=== Personal Notes
+
+In some use cases, it's useful to have personal notes that are separate from the presenter notes built
+into the presentation itself. For example, you might share a presentation repository with others, but would
+like the ability add your own notes to slides. This can be done by creating a markdown file in the
+<tt>_notes</tt> directory of your presentation. The filename should mirror the name of the slide.
+
+For example, if the name as displayed in the upper left of the presenter view was <tt>Introduction/About</tt>
+then the personal notes file should be <tt>_notes/Introduction/About.md</tt>.
+
 == Handout Notes
 
 Surround handout notes with <tt>~~~SECTION:handouts~~~</tt> and <tt>~~~ENDSECTION~~~</tt> tags. It will

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -315,6 +315,24 @@ div.zoomed {
     list-style-type: disc;
   }
 
+  #bottom #notes div.personal {
+    float: right;
+    border-left: 4px solid #999;
+    border-bottom: 4px solid #999;
+    border-radius: 0 0 0 0.5em;
+    padding: 0.1em 0 0.25em 0.25em;
+    margin: 0 0 1em 1em;
+    background: #eee;
+    max-width: 25%;
+  }
+
+  #bottom #notes div.personal h1 {
+    font-size: 1em;
+    font-weight: bold;
+    margin-top: 0;
+    border-bottom: 1px solid #ccc;
+  }
+
 #topbar {
   background: #4c4c4c; /* Old browsers */
   /* IE9 SVG, needs conditional override of 'filter' to 'none' */


### PR DESCRIPTION
In some use cases, it's nice to have the ability to add personal notes
to be displayed alongside the built in presenter notes. This commit
allows you to do this. Just create a short markdown file in `_notes` that
matches the complete pathname of the slide that you'd like to add notes to.

You may need to empty your browser cache before this displays properly
for the first time.
