### PR TITLE
Clean up notes css a bit

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -289,7 +289,6 @@ div.zoomed {
     height: 100%;
     font-family: helvetica;
     font-weight: 100;
-    padding: 0 0.25em;
   }
   #notes p,
   #notes h1,
@@ -299,13 +298,15 @@ div.zoomed {
   #notes ol,
   #notes ul {
     margin-right: 0.75em;
+    padding-left: 0.25em;
   }
   #notes p {
-    padding: 0.1em inherit;
+    padding: 0.25em;
     margin-bottom: 0.5em;
   }
   #notes ol, #notes ul {
     padding-left: 2em;
+    padding-top: 0.25em;
     margin-bottom: 0.5em;
   }
   #notes ol {


### PR DESCRIPTION
This fixes #201, the spacing issue on Firefox. It also makes the grid
line up perfectly every time.
