### PR TITLE
Allow background images to scale to fill the slide

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -100,6 +100,7 @@ Some useful styles for each slide are:
 [noprint] this slide will not appear in the printed version of the presentation
 [supplemental] rather than adding a slide to the main presentation, add a slide to supplemental materials. See below.
 [form=id] Render form elements on this slide with a given form ID. See below, and in FORMS.rdoc.
+[background-fit] Scales a background image to the largest size that both height and width are onscreen. The default is to completely fill the slide.
 
 Check out the example directory included to see examples of most of these.
 
@@ -160,6 +161,10 @@ The transitions are provided by jQuery Cycle plugin. See http://www.malsup.com/j
 A custom per slide background can be set in the slide options. For example:
 
      !SLIDE[bg=customLogo.png]
+
+By default, the background will be scaled to completely cover the slide. If you
+specify the <tt>background-fit</tt> slide style, then the background will be
+scaled to the largest size that both height and width fit within the slide.
 
 = Language Highlighting
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -277,7 +277,7 @@ class ShowOff < Sinatra::Application
         classes = content_classes.join(' ')
         content = "<div"
         content += " id=\"#{id}\"" if id
-        content += " style=\"background: url('file/#{slide.bg}') center no-repeat;\"" if slide.bg
+        content += " style=\"background-image: url('file/#{slide.bg}');\"" if slide.bg
         content += " class=\"slide #{classes}\" data-transition=\"#{transition}\">"
 
         # name the slide. If we've got multiple slides in this file, we'll have a sequence number

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -18,6 +18,13 @@
       -webkit-box-shadow:0 0 25px rgba(0,0,0,0.35);
       -moz-box-shadow:0 0 25px rgba(0,0,0,0.35);
       box-shadow:0 0 25px rgba(0,0,0,0.35);
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: cover;
+  }
+
+  #preso, .slide.background-fit {
+      background-size: contain;
   }
 
   #footer {


### PR DESCRIPTION
The default is to scale the background to cover the slide. If you
specify a slide style os `background-fit` then the background will
be scaled to the largest size that completely fits on-slide.

Fixes #181
