### PR TITLE
Remove synv button from static export

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -4,7 +4,7 @@ var ShowOff = {};
 
 var preso_started = false
 var slidenum = 0
-var presenterSlideNum = 0
+var presenterSlideNum = null
 var slideTotal = 0
 var slides
 var currentSlide


### PR DESCRIPTION
When a presentation is exported as static HTML, the code that resets
this to `null` doesn't ever get run. So let's just start out with it at
null, and that way the static page doesn't show a useless Sync button.